### PR TITLE
9 POST Admin Volunteers

### DIFF
--- a/src/app/api/admin/volunteers/route.ts
+++ b/src/app/api/admin/volunteers/route.ts
@@ -1,9 +1,11 @@
 import { supabase } from "@/supabase-client";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { Database } from "@/database/database.types";
-import { postgrestErrorToHttpStatus } from "@/database/utils";
+import { hasOnlyAllowedKeys, isDate, isEmail, isPhone, postgrestErrorToHttpStatus } from "@/database/utils";
 
-type Volunteer = Database["public"]["Tables"]["volunteers"]["Row"];
+type VolunteerRow = Database["public"]["Tables"]["volunteers"]["Row"];
+type VolunteerInsert = Database["public"]["Tables"]["volunteers"]["Insert"];
+const VOLUNTEER_INSERT_KEYS = ["email", "firstname", "lastname", "phone", "joined", "trees_planted", "type"] as const;
 
 /**
  * Admin GET API route for all volunteer information.
@@ -11,28 +13,61 @@ type Volunteer = Database["public"]["Tables"]["volunteers"]["Row"];
  */
 export async function GET() {
   try {
-    const { data, error } = await supabase
-      .from<"volunteers", Volunteer>("volunteers")
-      .select("*")
-      .order("created_at", { ascending: true });
+    const { data, error } = await supabase.from("volunteers").select("*").order("created_at", { ascending: true });
 
     if (error) {
       console.error("Supabase error fetching volunteers:", error.message);
       return NextResponse.json({ message: error.message }, { status: postgrestErrorToHttpStatus(error) });
     }
 
-    const normalizedData: Volunteer[] = data ?? [];
+    const normalizedData: VolunteerRow[] = data ?? [];
     return NextResponse.json({ message: normalizedData }, { status: 200 });
   } catch (error) {
-    console.error("Unexpected error in /api/admin/volunteers; ", error);
+    console.error("Unexpected error in /api/admin/volunteers GET: ", error);
     return NextResponse.json({ message: "Unexpected server error" }, { status: 500 });
   }
 }
 
 /**
- * Example POST API route. REPLACE THIS DOCSTRING.
- * @returns {message: string}
+ * Admin POST API route for creating a volunteer.
+ * @param request
+ * @returns {message: VolunteerRow, status: number}
  */
-export async function POST() {
-  return NextResponse.json({ message: "Example volunteers POST message" });
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    if (!isVolunteerInsert(body)) return NextResponse.json({ message: "Invalid request body" }, { status: 400 });
+
+    const { data, error } = await supabase.from("volunteers").insert(body).select().single<VolunteerRow>();
+
+    if (error) {
+      console.log("Supabase error creating volunteer:", error.message);
+      return NextResponse.json({ message: error.message }, { status: postgrestErrorToHttpStatus(error) });
+    }
+
+    return NextResponse.json({ message: data }, { status: 201 });
+  } catch (error) {
+    console.error("Unexpected error in /api/admin/volunteers POST:", error);
+    return NextResponse.json({ message: "Unexpected server error" }, { status: 500 });
+  }
+}
+
+function isVolunteerInsert(obj: unknown): obj is VolunteerInsert {
+  if (!hasOnlyAllowedKeys(obj, VOLUNTEER_INSERT_KEYS)) return false;
+  const vol = obj as Record<string, unknown>;
+
+  return (
+    isEmail(vol.email) &&
+    typeof vol.firstname === "string" &&
+    vol.firstname.trim().length > 0 &&
+    typeof vol.lastname === "string" &&
+    vol.lastname.trim().length > 0 &&
+    isPhone(vol.phone) &&
+    (vol.joined === undefined || isDate(vol.joined)) &&
+    (vol.type === undefined || typeof vol.type === "string") &&
+    (vol.trees_planted === undefined ||
+      vol.trees_planted === null ||
+      (Array.isArray(vol.trees_planted) && vol.trees_planted.every((t) => typeof t === "string")))
+  );
 }

--- a/src/app/api/admin/volunteers/route.ts
+++ b/src/app/api/admin/volunteers/route.ts
@@ -5,7 +5,6 @@ import { hasOnlyAllowedKeys, isDate, isEmail, isPhone, postgrestErrorToHttpStatu
 
 type VolunteerRow = Database["public"]["Tables"]["volunteers"]["Row"];
 type VolunteerInsert = Database["public"]["Tables"]["volunteers"]["Insert"];
-const VOLUNTEER_INSERT_KEYS = ["email", "firstname", "lastname", "phone", "joined", "trees_planted", "type"] as const;
 
 /**
  * Admin GET API route for all volunteer information.
@@ -37,8 +36,6 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
 
-    if (!isVolunteerInsert(body)) return NextResponse.json({ message: "Invalid request body" }, { status: 400 });
-
     const { data, error } = await supabase.from("volunteers").insert(body).select().single<VolunteerRow>();
 
     if (error) {
@@ -53,7 +50,11 @@ export async function POST(request: NextRequest) {
   }
 }
 
+/**
+ * @deprecated No longer validating NextRequests.
+ */
 function isVolunteerInsert(obj: unknown): obj is VolunteerInsert {
+  const VOLUNTEER_INSERT_KEYS = ["email", "firstname", "lastname", "phone", "joined", "trees_planted", "type"] as const;
   if (!hasOnlyAllowedKeys(obj, VOLUNTEER_INSERT_KEYS)) return false;
   const vol = obj as Record<string, unknown>;
 

--- a/src/database/utils.ts
+++ b/src/database/utils.ts
@@ -31,3 +31,54 @@ export function postgrestErrorToHttpStatus(error: PostgrestError): number {
   // Default: server error
   return 500;
 }
+
+/**
+ * Validate whether an object only contains allowed keys
+ * @param obj
+ * @param allowedKeys
+ * @returns boolean
+ */
+export function hasOnlyAllowedKeys(obj: unknown, allowedKeys: readonly string[]): boolean {
+  if (!obj || typeof obj !== "object") return false;
+  const keys = Object.keys(obj as Record<string, unknown>);
+  return keys.every((k) => allowedKeys.includes(k));
+}
+
+/**
+ * Validate whether a value is of a valid email structure
+ * @param value
+ * @returns boolean
+ */
+export function isEmail(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+
+  if (!value.includes("@")) return false;
+
+  const email = value.trim();
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+/**
+ * Validate whether a value is of a valid phone number structure
+ * @param value
+ * @returns boolean
+ */
+export function isPhone(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+
+  return /^[\d\s()+-]{7,20}$/.test(value);
+}
+
+/**
+ * Validate whether a value is a valid date
+ * @param value
+ * @returns boolean
+ */
+export function isDate(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime());
+}

--- a/src/database/utils.ts
+++ b/src/database/utils.ts
@@ -6,16 +6,28 @@ import { PostgrestError } from "@supabase/supabase-js";
  * @returns number
  */
 export function postgrestErrorToHttpStatus(error: PostgrestError): number {
-  switch (error.code) {
-    case "42501":
-      return 403;
-    case "PGRST116":
-      return 404;
-    case "23505":
-      return 409;
-    case "22P02":
-      return 400;
-    default:
-      return 500;
-  }
+  const code = error.code ?? "";
+
+  // PostgREST "no rows found" often triggered by .single()
+  if (code === "PGRST116") return 404;
+
+  // Auth / permission
+  if (code === "42501") return 403;
+
+  // Uniqueness / conflicts
+  if (code === "23505") return 409; // unique_violation
+  if (code === "23503") return 409; // foreign_key_violation
+
+  // Client input errors (validation / bad data)
+  if (code === "22P02") return 400; // invalid_text_representation
+  if (code === "23502") return 400; // not_null_violation
+  if (code === "23514") return 400; // check_violation
+  if (code === "22001") return 400; // string_data_right_truncation
+  if (code === "22003") return 400; // numeric_value_out_of_range
+
+  // other "22xxx" data exceptions
+  if (code.startsWith("22")) return 400;
+
+  // Default: server error
+  return 500;
 }


### PR DESCRIPTION
## Developer: Will Heath
Closes #9

### Pull Request Summary

Completed POST endpoint for api/admin/volunteers; includes request body validation and error handling.

### Modifications

**Modified files:**
src/app/api/admin/volunteers/route.ts
* Completed POST endpoint
* Volunteer Insert object validation function
* ever so slightly tweaked the GET endpoint in the same file; retested and still functional.

src/database/utils.ts
 * updated postgrest to http status function to accomidate more status codes
 * email, phone, and date string validation functions
 * object key validation

### Testing Considerations

Many variations of valid Volunteer Insert objects have been tested including ones with and without optional fields.
Many variations of invalid Volunteer Insert objects have been tested including:
* extra fields
* missing fields
* invalid phone, email, and/or date
* empty string names

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="1355" height="1870" alt="ECOSLO-9-post-admin-api-test-1" src="https://github.com/user-attachments/assets/f98ac366-c087-449a-a6ad-7a6f60fbbf62" />

<img width="1367" height="1760" alt="ECOSLO-9-post-admin-api-test-2" src="https://github.com/user-attachments/assets/21e5d3fb-6f70-493f-886d-9b6d35c2ff0d" />


<img width="1360" height="1325" alt="ECOSLO-9-post-admin-api-test-3" src="https://github.com/user-attachments/assets/e26f4d28-c7ab-4bef-9e9e-02f254a8a1d8" />

<img width="1345" height="1367" alt="ECOSLO-9-post-admin-api-test-4" src="https://github.com/user-attachments/assets/8861762b-4da3-446e-abd8-5ca9929fab67" />
