### PR TITLE
5/get admin trees slug

### DIFF
--- a/src/app/api/admin/trees/[id]/route.ts
+++ b/src/app/api/admin/trees/[id]/route.ts
@@ -9,11 +9,23 @@ type IParams = {
 };
 
 /**
- * Example GET API route. REPLACE THIS DOCSTRING.
- * @returns {message: string}
+ * Returns a single tree row by id
+ * @returns { body: Tree[], status: number } if successful
+ * @returns { message: string, status: number} if error
  */
-export async function GET() {
-  return NextResponse.json({ message: "Example trees slug GET message" });
+export async function GET(req: NextRequest, { params }: IParams) {
+  const { id } = await params;
+
+  try {
+    const message = await supabase.from("trees").select().eq("id", id);
+    if (message.error) {
+      return NextResponse.json({ error: message.error }, { status: postgrestErrorToHttpStatus(message.error) });
+    }
+
+    return NextResponse.json({ message: message.data }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ message: "Unexpected Server Error" });
+  }
 }
 
 /**

--- a/src/app/api/admin/trees/[id]/route.ts
+++ b/src/app/api/admin/trees/[id]/route.ts
@@ -12,6 +12,7 @@ type IParams = {
  * Returns a single tree row by id
  * @returns { body: Tree[], status: number } if successful
  * @returns { message: string, status: number} if error
+ * @returns {message: null, status: number} if tree not found
  */
 export async function GET(req: NextRequest, { params }: IParams) {
   const { id } = await params;
@@ -22,7 +23,7 @@ export async function GET(req: NextRequest, { params }: IParams) {
       return NextResponse.json({ error: message.error }, { status: postgrestErrorToHttpStatus(message.error) });
     }
 
-    return NextResponse.json({ message: message.data }, { status: 200 });
+    return NextResponse.json({ message: message.data.length == 0 ? null : message.data }, { status: 200 });
   } catch (error) {
     return NextResponse.json({ message: "Unexpected Server Error" });
   }

--- a/src/app/api/admin/trees/[id]/route.ts
+++ b/src/app/api/admin/trees/[id]/route.ts
@@ -18,14 +18,14 @@ export async function GET(req: NextRequest, { params }: IParams) {
   const { id } = await params;
 
   try {
-    const message = await supabase.from("trees").select().eq("id", id);
+    const message = await supabase.from("trees").select().eq("id", id).maybeSingle();
     if (message.error) {
       return NextResponse.json({ error: message.error }, { status: postgrestErrorToHttpStatus(message.error) });
     }
 
-    return NextResponse.json({ message: message.data.length == 0 ? null : message.data }, { status: 200 });
+    return NextResponse.json({ message: message.data }, { status: 200 });
   } catch (error) {
-    return NextResponse.json({ message: "Unexpected Server Error" });
+    return NextResponse.json({ message: "Unexpected Server Error" }, { status: 500 });
   }
 }
 
@@ -46,7 +46,7 @@ export async function PUT(req: NextRequest, { params }: IParams) {
 
     return NextResponse.json({ message: message.data }, { status: 200 });
   } catch (error) {
-    return NextResponse.json({ message: "Unexpected Server Error" });
+    return NextResponse.json({ message: "Unexpected Server Error" }, { status: 500 });
   }
 }
 


### PR DESCRIPTION
## Developer: Rudy Good

Closes #5 

### Pull Request Summary

Create a GET method to get trees by a given id slug

### Modifications

- Changed the GET method in app/api/admin/trees/[id] from a boilerplate method to a working GET method

### Testing Considerations

- The GET request correctly returns all tree data when a given ID exists.
- The GET request correctly throws an error using the postgressErrorToHttpStatus method when there's an error
- The GET request correctly returns a null message when a tree's id is not found in the database.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

Working GET request:
<img width="1983" height="1409" alt="image" src="https://github.com/user-attachments/assets/d6e4812a-0461-4c57-bd80-910b1c9aa830" />

Failed GET request (I turned my internet off):
<img width="1978" height="1438" alt="image" src="https://github.com/user-attachments/assets/2dbc6fd5-75d7-45d8-ae55-0470825ec0a7" />

GET request on an ID that doesn't exist:
<img width="1981" height="1423" alt="image" src="https://github.com/user-attachments/assets/b50a1521-8ad0-4fa8-bb6f-b122d28073d1" />

