### PR TITLE
Implement DELETE API for admin volunteers

### DIFF
--- a/src/app/api/admin/volunteers/[id]/route.ts
+++ b/src/app/api/admin/volunteers/[id]/route.ts
@@ -45,6 +45,18 @@ export async function PUT(request: NextRequest, { params }: { params: IParams })
   }
 }
 
+/**
+ * DELETE API ROUTE: Deletes a volunteer record by their ID
+ *
+ * Removes a volunteer from the database using the provided volunteer ID.
+ *
+ * The volunteer is identified by their ID which is found in the params attribute.
+ *
+ * Parameters:
+ * @param request - the incoming request (not used for DELETE)
+ * @param params - an object that contains parameters
+ * @param params.id - the ID of the volunteer to delete*/
+
 export async function DELETE(_request: NextRequest, { params }: { params: IParams }) {
   try {
     const id = params.id;

--- a/src/app/api/admin/volunteers/[id]/route.ts
+++ b/src/app/api/admin/volunteers/[id]/route.ts
@@ -45,10 +45,23 @@ export async function PUT(request: NextRequest, { params }: { params: IParams })
   }
 }
 
-/**
- * Example DELETE API route. REPLACE THIS DOCSTRING.
- * @returns {message: string}
- */
-export async function DELETE() {
-  return NextResponse.json({ message: "Example volunteers slug DELETE message" });
+export async function DELETE(_request: NextRequest, { params }: { params: IParams }) {
+  try {
+    const id = params.id;
+
+    if (!id) {
+      return NextResponse.json({ message: "Volunteer ID is required" }, { status: 422 });
+    }
+
+    const message = await supabase.from("volunteers").delete().eq("id", id).select().single();
+
+    if (message.error) {
+      const status = postgrestErrorToHttpStatus(message.error);
+      return NextResponse.json({ error: message.error }, { status });
+    }
+
+    return NextResponse.json({ message: message.data }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ message: "Unexpected server error" }, { status: 500 });
+  }
 }


### PR DESCRIPTION
## Developer: Mohini Chahal

Closes #12

### Pull Request Summary

- Implemented the DELETE API route for the admin Volunteers table.  
- This allows an admin to delete a single volunteer by their ID using the slug `[id]` in the API URL
- The deleted volunteer is returned in the response. 

### Modifications

`src/app/api/admin/volunteers/[id]/route.ts`  
  - Added `DELETE` function that deletes a volunteer by ID.  

### Testing Considerations

Tested locally using **Postman**:
  - Method: `DELETE`
  - URL: `http://localhost:3000/api/admin/volunteers/1`  
  - Verified that the deleted volunteer is returned in the response.  
  - Verified 404/422 responses when an invalid or missing ID is used.
  - 
### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="956" height="542" alt="Screenshot 2026-01-27 at 10 33 12 PM" src="https://github.com/user-attachments/assets/1c46db83-8cef-4983-8f1e-a244dffd5a06" />
