### PR TITLE
7/delete-admin-trees

### DIFF
--- a/src/app/api/admin/trees/[id]/route.ts
+++ b/src/app/api/admin/trees/[id]/route.ts
@@ -38,9 +38,21 @@ export async function PUT(req: NextRequest, { params }: IParams) {
 }
 
 /**
- * Example DELETE API route. REPLACE THIS DOCSTRING.
- * @returns {message: string}
+ * Deletes one tree row by id, returns deleted tree
+ * @returns { message: Tree, status: number } if successful
+ * @returns { message: string, status: number } if error
  */
-export async function DELETE() {
-  return NextResponse.json({ message: "Example trees slug DELETE message" });
+export async function DELETE(req: NextRequest, { params }: IParams) {
+  try {
+    const { id } = await params;
+    const { data, error } = await supabase.from("trees").delete().eq("id", id).limit(1).select().single();
+
+    if (error) {
+      return NextResponse.json({ message: error.message }, { status: postgrestErrorToHttpStatus(error) });
+    }
+
+    return NextResponse.json({ message: data }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ message: "Unexpected Server Error" }, { status: 500 });
+  }
 }


### PR DESCRIPTION
## Developer: Oliver Cushman

Closes #7 

### Pull Request Summary

Adds delete endpoint for trees, allowing admins to delete exactly one tree from the table and fetch it as a result from the endpoint.

I was unsure if we are supposed to be using the auth logic used in one of the POST requests, let me know if that is currently our standard and I'll make the switch ASAP.

### Modifications

src\app\api\admin\trees\[id]\route.ts - Added DELETE endpoint

### Testing Considerations

Tested both successful scenarios and error scenarios, such as when the given id does not exist. Made sure that the endpoint returns the deleted tree.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
Valid id:
<img width="827" height="547" alt="image" src="https://github.com/user-attachments/assets/89fe85fd-cac3-4590-ba9c-60e6092ed6b2" />
Invalid id:
<img width="824" height="338" alt="image" src="https://github.com/user-attachments/assets/bdd15dc8-40b2-41df-8505-909bb2b6eb41" />

