### PR TITLE
fix: table height bug

### DIFF
--- a/src/components/TreePageTableWidget.tsx
+++ b/src/components/TreePageTableWidget.tsx
@@ -60,7 +60,7 @@ function TreePageTableWidget({
           <div className="w-full h-full flex justify-center items-center text-red-500">{error}</div>
         ) : (
           <TreePageTable
-            className="w-full max-w-full min-w-0 h-[80vh]"
+            className="w-full max-w-full min-w-0 max-h-[80vh]"
             onRowClick={onRowClick}
             onTableReady={onTableReady}
             data={trees}


### PR DESCRIPTION
## Developer: Will Heath

Closes #N/A

### Pull Request Summary

Table height was not adjusting when there where less elements then the height of the table. Currently this is ugly. I could make this a feature where the table can be taller than the number of elements in it, but currently it is not. I changed the behavior to have a max height but shrink when less elements are present.

### Modifications

added max-h-[80vh] to table in tree page.

### Testing Considerations

{list out what you have tested and what the reviewer should verify}

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
