### PR TITLE
feat: Adds new supabase tables types for Reminders, Templates, and Su…

### DIFF
--- a/src/database/database.types.ts
+++ b/src/database/database.types.ts
@@ -47,6 +47,78 @@ export type Database = {
         };
         Relationships: [];
       };
+      reminders: {
+        Row: {
+          assignees: number[];
+          created_at: string;
+          crons_expression: string;
+          id: number;
+          is_active: boolean;
+          is_group_task: boolean;
+          name: string;
+          task_message: string;
+        };
+        Insert: {
+          assignees: number[];
+          created_at?: string;
+          crons_expression?: string;
+          id?: number;
+          is_active?: boolean;
+          is_group_task?: boolean;
+          name?: string;
+          task_message?: string;
+        };
+        Update: {
+          assignees?: number[];
+          created_at?: string;
+          crons_expression?: string;
+          id?: number;
+          is_active?: boolean;
+          is_group_task?: boolean;
+          name?: string;
+          task_message?: string;
+        };
+        Relationships: [];
+      };
+      surveys: {
+        Row: {
+          body: Json;
+          created_at: string;
+          id: number;
+          task: number | null;
+          tree: number | null;
+        };
+        Insert: {
+          body: Json;
+          created_at?: string;
+          id?: number;
+          task?: number | null;
+          tree?: number | null;
+        };
+        Update: {
+          body?: Json;
+          created_at?: string;
+          id?: number;
+          task?: number | null;
+          tree?: number | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "surveys_task_fkey";
+            columns: ["task"];
+            isOneToOne: false;
+            referencedRelation: "tasks";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "surveys_tree_fkey";
+            columns: ["tree"];
+            isOneToOne: false;
+            referencedRelation: "trees";
+            referencedColumns: ["ecoslo_num"];
+          },
+        ];
+      };
       tasks: {
         Row: {
           assignees: number[] | null;
@@ -77,6 +149,33 @@ export type Database = {
           message?: string;
           surveys_needed?: number;
           title?: string;
+        };
+        Relationships: [];
+      };
+      templates: {
+        Row: {
+          assignees: number[];
+          created_at: string;
+          crons_expression: string;
+          id: number;
+          is_group_task: boolean;
+          task_message: string;
+        };
+        Insert: {
+          assignees: number[];
+          created_at?: string;
+          crons_expression?: string;
+          id?: number;
+          is_group_task?: boolean;
+          task_message?: string;
+        };
+        Update: {
+          assignees?: number[];
+          created_at?: string;
+          crons_expression?: string;
+          id?: number;
+          is_group_task?: boolean;
+          task_message?: string;
         };
         Relationships: [];
       };


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

Adds types for new Supabase tables: Reminders, Templates, and Surveys.

Ran:

```
npx supabase gen types typescript --project-id "$PROJECT_REF" --schema public > ./database/database.types.ts
```

### Modifications

Updates `/database/database.types.ts` with new table types.

### Testing Considerations

N/A

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

N/A
