### PR TITLE
feat: column selection and mobile friendly trees page

### DIFF
--- a/src/app/(admin)/trees/page.tsx
+++ b/src/app/(admin)/trees/page.tsx
@@ -6,25 +6,50 @@ import { TreeSchema } from "@/components/data-table/table-widget-defs";
 import TreeDetailsPopout from "@/components/TreeDetailsPopout";
 import { useRef } from "react";
 import { Table } from "@/components/data-table/table/table-types";
+import { Download, Plus } from "lucide-react";
+import { downloadTreeCSV, dataToCSV } from "./utils/csv";
 
 export default function Trees() {
   const [currentTree, setCurrentTree] = useState<TreeSchema | null>(null);
   const tableRef = useRef<Table<TreeSchema> | null>(null);
 
   return (
-    <main className="flex-1 min-w-0 bg-[#FBF7EE]" onClick={() => setCurrentTree(null)}>
+    <main className="flex-1 min-w-0 bg-background" onClick={() => setCurrentTree(null)}>
       <div className="fixed top-3 -right-100 h-auto w-auto z-30 ">
         <TreeDetailsPopout admin={true} tree={currentTree ? currentTree : undefined}></TreeDetailsPopout>
       </div>
-      <div className="px-6 py-10">
+      <div className="flex flex-col gap-y-8 px-6 py-10">
         {/* header */}
-        <header className="flex items-center justify-between pt-5">
-          <h1 className="flex-1 text-[56px] font-[Constantia] font-semibold leading-none">Trees</h1>
+        <header className="w-full flex items-center justify-between pb-2">
+          <h1 className="text-5xl font-[Constantia] font-semibold leading-none">Trees</h1>
+          <div className="flex gap-4 items-center">
+            <button
+              className="flex items-center gap-x-2 px-4 py-2 bg-transparent border border-border text-text-dark rounded-full hover:bg-black/5 transition-colors duration-100"
+              onClick={() => {
+                downloadTreeCSV(
+                  dataToCSV(
+                    tableRef?.current?.getRowModels().map((rowModel) => {
+                      const row: Record<string, unknown> = {};
+                      rowModel.cells.forEach((cell) => {
+                        row[cell.column.id] = cell.value;
+                      });
+                      return row;
+                    }) ?? [],
+                  ),
+                );
+              }}
+            >
+              <span className="font-medium">Export CSV</span>
+              <Download className="w-4 h-4" />
+            </button>
+            <button className="flex items-center gap-x-2 px-4 py-2 bg-primary text-text-light border border-border text-text-dark rounded-full hover:bg-primary/90 transition-colors duration-100">
+              <span className="font-medium">Add Tree</span>
+              <Plus className="w-4 h-4" />
+            </button>
+          </div>
         </header>
         {/* control panel placeholder */}
-        <div className="mt-10 rounded-3xl border-2 border-[#CDAA7F] bg-[#EEE0CF] p-3">
-          <ControlPanel tableRef={tableRef} />
-        </div>
+        <ControlPanel tableRef={tableRef} />
         {/* trees table placeholder */}
         <TreePageTableWidget
           onRowClick={(event, tree) => {
@@ -34,7 +59,7 @@ export default function Trees() {
           onTableReady={(table) => {
             tableRef.current = table;
           }}
-          className="mt-8 w-full max-w-full"
+          className="w-full max-w-full"
         />
       </div>
     </main>

--- a/src/app/(admin)/trees/page.tsx
+++ b/src/app/(admin)/trees/page.tsx
@@ -24,7 +24,7 @@ export default function Trees() {
           <h1 className="text-5xl font-[Constantia] font-semibold leading-none">Trees</h1>
           <div className="flex gap-4 items-center">
             <button
-              className="flex items-center gap-x-2 px-4 py-2 bg-transparent border border-border text-text-dark rounded-full hover:bg-black/5 transition-colors duration-100"
+              className="flex items-center gap-x-2 px-4 py-2 text-text-dark bg-button-light border border-border shadow-xs rounded-full hover:bg-button-light/60 transition-colors duration-100"
               onClick={() => {
                 downloadTreeCSV(
                   dataToCSV(

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -149,7 +149,6 @@ function ControlFilterDropdown(props: ControlFilterDropdownInterface) {
   const [isOpen, setIsOpen] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  //const longestItem = props.dropDown.reduce((a, b) => (a.length > b.length ? a : b), "");
   useEffect(() => {
     return () => {
       if (timeoutRef.current) {
@@ -192,51 +191,6 @@ function ControlFilterDropdown(props: ControlFilterDropdownInterface) {
         </DropdownMenuContent>
       </DropdownMenu>
     </div>
-    // <div className="flex flex-col gap-1.5 relative select-none w-fit">
-    //   <h2 className="text-lg font-medium text-black">{props.text}</h2>
-
-    //   <div
-    //     className="h-11 rounded-full cursor-pointer bg-[#FFFCF5] outline-1 outline-black overflow-hidden"
-    //     onMouseDown={() => setIsOpen(!isOpen)}
-    //   >
-    //     <div className="relative h-full px-4">
-    //       <div
-    //         className="invisible h-0 flex items-center gap-6 text-lg font-medium whitespace-nowrap"
-    //         aria-hidden="true"
-    //       >
-    //         {longestItem}
-    //         <div className="w-4" />
-    //       </div>
-
-    //       <div className="absolute inset-0 px-4 flex items-center justify-between gap-2.5 text-base font-medium">
-    //         <span className="truncate">{props.dropDown[activeIndex]}</span>
-    //         <Image
-    //           src="/icons/dropdown.svg"
-    //           width={18}
-    //           height={18}
-    //           alt=""
-    //           className={`shrink-0 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
-    //         />
-    //       </div>
-    //     </div>
-    //   </div>
-
-    //   {isOpen && (
-    //     <div className="absolute top-full left-0 right-0 mt-1.5 bg-white rounded-xl z-200 shadow-md outline-1 outline-black/10 overflow-hidden">
-    //       {props.dropDown.map((item, index) => (
-    //         <div
-    //           key={index}
-    //           className={`px-4 py-2.5 cursor-pointer text-lg font-medium hover:bg-[#F1E6D9] transition-colors whitespace-nowrap ${
-    //             index === activeIndex ? "bg-[#F1E6D9]" : ""
-    //           }`}
-    //           onClick={() => handleSelect(index)}
-    //         >
-    //           {item}
-    //         </div>
-    //       ))}
-    //     </div>
-    //   )}
-    // </div>
   );
 }
 

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,43 +1,52 @@
 "use client";
 
-import { ChangeEvent, type MutableRefObject, useEffect, useRef, useState } from "react";
+import { ChangeEvent, type MutableRefObject, type ReactNode, useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import { TreeSchema } from "./data-table/table-widget-defs";
 import { Table } from "./data-table/table/table-types";
-import { dataToCSV, downloadTreeCSV } from "@/app/(admin)/trees/utils/csv";
+import { Check, ChevronDown, Search, X } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
 
 interface ControlSearchProps {
+  query: string;
+  onQueryChange: (query: string) => void;
   searchDelay: number;
-  searchFunction: (status: string) => void;
+  searchFunction: (query: string) => void;
 }
 
 function ControlSearch(props: ControlSearchProps) {
-  const [query, setQuery] = useState("");
-
   useEffect(() => {
     const handler = setTimeout(() => {
-      props.searchFunction(query);
+      props.searchFunction(props.query);
     }, props.searchDelay);
 
     return () => {
       clearTimeout(handler);
     };
-  }, [query, props.searchDelay, props.searchFunction, props]);
+  }, [props.query, props.searchDelay, props.searchFunction, props]);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const next = e.target.value;
-    setQuery(next);
+    props.onQueryChange(next);
   };
 
   return (
-    <div className="h-14 rounded-2xl outline-1 outline-black bg-[#FFFCF5]">
+    <div className="flex items-center gap-2 px-3 py-2 rounded-full border border-border bg-foreground w-full">
+      <Search className="text-text-muted w-5 h-5" />
       <input
         type="text"
         id="query"
-        placeholder="Search by Tree # or Species..."
-        value={query}
+        placeholder="Search for tree fields..."
+        value={props.query}
         onChange={handleChange}
-        className="w-full px-4 py-3.5 text-lg text-black placeholder:text-black outline-none bg-transparent"
+        className="flex-1 text-text-dark font-medium placeholder:text-text-muted outline-none"
       />
     </div>
   );
@@ -78,14 +87,13 @@ function ControlButton(props: ControlButtonInterface) {
 interface ControlStatusPillsInterface {
   text: string;
   options: string[];
+  activeIndex: number;
+  onActiveIndexChange: (index: number) => void;
   delay: number; // Delay in ms before calling delayFunction
   delayFunction: (status: string) => void;
-  activeBackgroundHex: string;
-  activeTextHex: string;
 }
 
 function ControlStatusPills(props: ControlStatusPillsInterface) {
-  const [activeIndex, setActiveIndex] = useState(0);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
@@ -97,7 +105,7 @@ function ControlStatusPills(props: ControlStatusPillsInterface) {
   }, []);
 
   const handleSelect = (index: number) => {
-    setActiveIndex(index);
+    props.onActiveIndexChange(index);
 
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
@@ -109,21 +117,18 @@ function ControlStatusPills(props: ControlStatusPillsInterface) {
   };
 
   return (
-    <div className="flex flex-col gap-1.5 select-none">
-      <h2 className="text-lg font-medium text-black">{props.text}</h2>
+    <div className="flex flex-col gap-2 select-none">
+      <h2 className="text-text-muted font-semibold">{props.text}</h2>
       <div className="flex gap-2">
         {props.options.map((option, index) => (
-          <div
+          <button
             key={index}
-            className="h-11 rounded-xl cursor-pointer outline-1 outline-black flex items-center justify-center px-5 transition-colors"
+            className={`rounded-2xl cursor-pointer flex items-center justify-center px-2 min-w-16 lg:min-w-30 py-1 transition-colors
+              ${index === props.activeIndex ? "bg-primary text-text-light hover:bg-primary/90" : "bg-button text-text-dark border border-border hover:bg-button/50"}`}
             onClick={() => handleSelect(index)}
-            style={{
-              backgroundColor: index === activeIndex ? props.activeBackgroundHex : "#FFFCF5",
-              color: index === activeIndex ? props.activeTextHex : "#000000",
-            }}
           >
-            <p className="font-medium text-lg whitespace-nowrap">{option}</p>
-          </div>
+            <p className="font-medium lg:text-lg whitespace-nowrap">{option}</p>
+          </button>
         ))}
       </div>
     </div>
@@ -131,18 +136,20 @@ function ControlStatusPills(props: ControlStatusPillsInterface) {
 }
 
 interface ControlFilterDropdownInterface {
-  text: string;
+  triggerClassName?: string;
+  label: string;
   dropDown: string[];
+  activeIndex: number;
+  onActiveIndexChange: (index: number) => void;
   delay: number; // Delay in ms before calling delayFunction
   delayFunction: (filter: string) => void;
 }
 
 function ControlFilterDropdown(props: ControlFilterDropdownInterface) {
-  const [activeIndex, setActiveIndex] = useState(0);
   const [isOpen, setIsOpen] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const longestItem = props.dropDown.reduce((a, b) => (a.length > b.length ? a : b), "");
+  //const longestItem = props.dropDown.reduce((a, b) => (a.length > b.length ? a : b), "");
   useEffect(() => {
     return () => {
       if (timeoutRef.current) {
@@ -152,7 +159,7 @@ function ControlFilterDropdown(props: ControlFilterDropdownInterface) {
   }, []);
 
   const handleSelect = (index: number) => {
-    setActiveIndex(index);
+    props.onActiveIndexChange(index);
 
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
@@ -164,50 +171,152 @@ function ControlFilterDropdown(props: ControlFilterDropdownInterface) {
   };
 
   return (
-    <div className="flex flex-col gap-1.5 relative select-none w-fit">
-      <h2 className="text-lg font-medium text-black">{props.text}</h2>
-
-      <div
-        className="h-11 rounded-full cursor-pointer bg-[#FFFCF5] outline-1 outline-black overflow-hidden"
-        onMouseDown={() => setIsOpen(!isOpen)}
-      >
-        <div className="relative h-full px-4">
-          <div
-            className="invisible h-0 flex items-center gap-6 text-lg font-medium whitespace-nowrap"
-            aria-hidden="true"
-          >
-            {longestItem}
-            <div className="w-4" />
-          </div>
-
-          <div className="absolute inset-0 px-4 flex items-center justify-between gap-2.5 text-base font-medium">
-            <span className="truncate">{props.dropDown[activeIndex]}</span>
-            <Image
-              src="/icons/dropdown.svg"
-              width={18}
-              height={18}
-              alt=""
-              className={`shrink-0 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
-            />
-          </div>
-        </div>
-      </div>
-
-      {isOpen && (
-        <div className="absolute top-full left-0 right-0 mt-1.5 bg-white rounded-xl z-200 shadow-md outline-1 outline-black/10 overflow-hidden">
+    <div className="flex flex-col gap-2 select-none">
+      <h2 className="text-text-muted font-semibold">{props.label}</h2>
+      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+        <DropdownMenuTrigger
+          className={`px-4 py-1.5 flex justify-between items-center bg-button-light border border-border text-text-dark rounded-full hover:bg-button-light/80 transition-colors duration-50 
+                    ${props.triggerClassName}`}
+        >
+          <span className="font-medium truncate">{props.dropDown[props.activeIndex]}</span>
+          <ChevronDown
+            className={`w-4 h-4 shrink-0 text-text-muted transition-transform duration-200 ${isOpen && "rotate-180"}`}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
           {props.dropDown.map((item, index) => (
-            <div
-              key={index}
-              className={`px-4 py-2.5 cursor-pointer text-lg font-medium hover:bg-[#F1E6D9] transition-colors whitespace-nowrap ${
-                index === activeIndex ? "bg-[#F1E6D9]" : ""
-              }`}
-              onClick={() => handleSelect(index)}
-            >
+            <DropdownMenuItem className="font-medium" onClick={() => handleSelect(index)} key={index}>
               {item}
-            </div>
+            </DropdownMenuItem>
           ))}
-        </div>
-      )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+    // <div className="flex flex-col gap-1.5 relative select-none w-fit">
+    //   <h2 className="text-lg font-medium text-black">{props.text}</h2>
+
+    //   <div
+    //     className="h-11 rounded-full cursor-pointer bg-[#FFFCF5] outline-1 outline-black overflow-hidden"
+    //     onMouseDown={() => setIsOpen(!isOpen)}
+    //   >
+    //     <div className="relative h-full px-4">
+    //       <div
+    //         className="invisible h-0 flex items-center gap-6 text-lg font-medium whitespace-nowrap"
+    //         aria-hidden="true"
+    //       >
+    //         {longestItem}
+    //         <div className="w-4" />
+    //       </div>
+
+    //       <div className="absolute inset-0 px-4 flex items-center justify-between gap-2.5 text-base font-medium">
+    //         <span className="truncate">{props.dropDown[activeIndex]}</span>
+    //         <Image
+    //           src="/icons/dropdown.svg"
+    //           width={18}
+    //           height={18}
+    //           alt=""
+    //           className={`shrink-0 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+    //         />
+    //       </div>
+    //     </div>
+    //   </div>
+
+    //   {isOpen && (
+    //     <div className="absolute top-full left-0 right-0 mt-1.5 bg-white rounded-xl z-200 shadow-md outline-1 outline-black/10 overflow-hidden">
+    //       {props.dropDown.map((item, index) => (
+    //         <div
+    //           key={index}
+    //           className={`px-4 py-2.5 cursor-pointer text-lg font-medium hover:bg-[#F1E6D9] transition-colors whitespace-nowrap ${
+    //             index === activeIndex ? "bg-[#F1E6D9]" : ""
+    //           }`}
+    //           onClick={() => handleSelect(index)}
+    //         >
+    //           {item}
+    //         </div>
+    //       ))}
+    //     </div>
+    //   )}
+    // </div>
+  );
+}
+
+interface SelectProps {
+  className?: string;
+  label: string;
+  checkedIcon?: ReactNode;
+  tableRef: MutableRefObject<Table<TreeSchema> | null>;
+  onCheckedItem: (item: string) => void;
+}
+
+type SelectItem = {
+  checked: boolean;
+  id: string;
+  name: string;
+};
+
+function Select(props: SelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [items, setItems] = useState<SelectItem[]>([]);
+
+  const syncItemsFromTable = () => {
+    const table = props.tableRef.current;
+    if (!table) return;
+
+    setItems(
+      table.getHideableColumns().map((column) => ({
+        checked: table.getColumnVisibility(column.id),
+        id: column.id,
+        name: column.name,
+      })),
+    );
+  };
+
+  const onCheckedChange = (item: string) => {
+    setItems((prev) => prev.map((entry) => (entry.id === item ? { ...entry, checked: !entry.checked } : entry)));
+    props.onCheckedItem(item);
+  };
+
+  return (
+    <div className={`flex flex-col gap-2 select-none ${props.className}`}>
+      <h2 className="text-text-muted font-semibold">{props.label}</h2>
+      <DropdownMenu
+        open={isOpen}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+          if (open) syncItemsFromTable();
+        }}
+      >
+        <DropdownMenuTrigger className="w-32 lg:w-64 px-4 py-1.5 flex justify-between items-center bg-button-light border border-border text-text-dark rounded-full hover:bg-button-light/80 transition-colors duration-50">
+          <span className="font-medium">Visibility</span>
+          <ChevronDown
+            className={`w-4 h-4 text-text-muted transition-transform duration-200 ${isOpen && "rotate-180"}`}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem
+            onClick={() => {
+              items.forEach((item) => {
+                if (!item.checked) onCheckedChange(item.id);
+                return item.checked;
+              });
+            }}
+          >
+            <span className="font-medium">Enable All</span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          {items.map((item) => (
+            <DropdownMenuCheckboxItem
+              className="font-medium"
+              checked={item.checked}
+              checkedIcon={props.checkedIcon}
+              onCheckedChange={() => onCheckedChange(item.id)}
+              key={item.id}
+            >
+              {item.name}
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }
@@ -223,92 +332,99 @@ export default function ControlPanel({ tableRef }: ControlPanelProps) {
   const CONDITION_STATUS_OPTIONS = ["All", "Good", "Fair", "Poor"];
   const VISIBILITY_STATUS_OPTIONS = ["All", "Public", "Private"];
   const QUERY_DELAY = 0;
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusActiveIndex, setStatusActiveIndex] = useState(0);
+  const [conditionActiveIndex, setConditionActiveIndex] = useState(0);
+  const [visibilityActiveIndex, setVisibilityActiveIndex] = useState(0);
+
+  const resetFilters = () => {
+    setSearchQuery("");
+    setStatusActiveIndex(0);
+    setConditionActiveIndex(0);
+    setVisibilityActiveIndex(0);
+    tableRef.current?.setSearchQuery("");
+    tableRef.current?.setColumnFilter("status", () => []);
+    tableRef.current?.setColumnFilter("condition", () => []);
+    tableRef.current?.setColumnFilter("is_public", () => []);
+  };
 
   return (
-    <div className="w-full">
-      <div className="flex w-full min-h-43 flex-col justify-center rounded-[40px] bg-inherit px-10 py-8">
-        <div className="flex justify-between items-center w-full gap-10">
-          <div className="flex flex-col gap-4 w-full">
-            <div className="w-256">
-              <ControlSearch
-                searchDelay={QUERY_DELAY}
-                searchFunction={(query: string) => {
-                  const trimmedQuery = query.trimStart();
-                  tableRef.current?.setSearchQuery(trimmedQuery);
-                }}
-              />
-            </div>
+    <div className="w-full flex flex-col gap-4 rounded-xl bg-card border border-border shadow-sm p-6 lg:p-8">
+      <ControlSearch
+        query={searchQuery}
+        onQueryChange={setSearchQuery}
+        searchDelay={QUERY_DELAY}
+        searchFunction={(query: string) => {
+          const trimmedQuery = query.trimStart();
+          tableRef.current?.setSearchQuery(trimmedQuery);
+        }}
+      />
 
-            <div className="flex gap-6 items-start">
-              <div className="pr-16">
-                <ControlStatusPills
-                  text="Status"
-                  options={CONTROL_STATUS_OPTIONS}
-                  delay={QUERY_DELAY}
-                  delayFunction={(status: string) =>
-                    tableRef.current?.setColumnFilter("status", () => (status === "All" ? [] : [status.toLowerCase()]))
-                  }
-                  activeBackgroundHex="#78855b"
-                  activeTextHex="#FFFFFF"
-                />
-              </div>
-              <div className="flex gap-16">
-                <ControlFilterDropdown
-                  text="Condition"
-                  dropDown={CONDITION_STATUS_OPTIONS}
-                  delay={QUERY_DELAY}
-                  delayFunction={(status: string) =>
-                    tableRef.current?.setColumnFilter("condition", () =>
-                      status === "All" ? [] : [status.toLowerCase()],
-                    )
-                  }
-                />
-                <ControlFilterDropdown
-                  text="Visibility"
-                  dropDown={VISIBILITY_STATUS_OPTIONS}
-                  delay={QUERY_DELAY}
-                  delayFunction={(status: string) =>
-                    tableRef.current?.setColumnFilter("is_public", () =>
-                      status === "All" ? [] : [status.toLowerCase()],
-                    )
-                  }
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-2 gap-4 shrink-0">
-            <ControlButton
-              backgroundHex="#FFFFFF"
-              hoverHex="#F5F5F5"
-              textHex="#000000"
-              text="Export CSV"
-              iconPath="/icons/download.svg"
-              function={() => {
-                // Use current row model state instead of internal data to ensure filters are applied to exported CSV
-                downloadTreeCSV(
-                  dataToCSV(
-                    tableRef?.current?.getRowModels().map((rowModel) => {
-                      const row: Record<string, unknown> = {};
-                      rowModel.cells.forEach((cell) => {
-                        row[cell.column.id] = cell.value;
-                      });
-                      return row;
-                    }) ?? [],
-                  ),
-                );
-              }}
+      <div className="flex justify-between items-start">
+        <div className="flex gap-4 items-start justify-start flex-wrap">
+          <ControlStatusPills
+            text="Status"
+            options={CONTROL_STATUS_OPTIONS}
+            activeIndex={statusActiveIndex}
+            onActiveIndexChange={setStatusActiveIndex}
+            delay={QUERY_DELAY}
+            delayFunction={(status: string) =>
+              tableRef.current?.setColumnFilter("status", () => (status === "All" ? [] : [status.toLowerCase()]))
+            }
+          />
+          <Select
+            className="block md:hidden"
+            label="Columns"
+            tableRef={tableRef}
+            checkedIcon={<Check />}
+            onCheckedItem={(item: string) => tableRef.current?.setColumnVisibility(item, (visible) => !visible)}
+          />
+          <div className="flex gap-4 min-w-0">
+            <ControlFilterDropdown
+              triggerClassName="w-32 lg:w-64"
+              label="Condition"
+              dropDown={CONDITION_STATUS_OPTIONS}
+              activeIndex={conditionActiveIndex}
+              onActiveIndexChange={setConditionActiveIndex}
+              delay={QUERY_DELAY}
+              delayFunction={(status: string) =>
+                tableRef.current?.setColumnFilter("condition", () => (status === "All" ? [] : [status.toLowerCase()]))
+              }
             />
-            <ControlButton
-              backgroundHex="#8A9573"
-              hoverHex="#7A8563"
-              textHex="#FFFFFF"
-              text="Add Tree"
-              iconPath="/icons/plus.svg"
-              function={() => console.log("Add function called")}
+            <ControlFilterDropdown
+              triggerClassName="w-32 lg:w-64"
+              label="Visibility"
+              dropDown={VISIBILITY_STATUS_OPTIONS}
+              activeIndex={visibilityActiveIndex}
+              onActiveIndexChange={setVisibilityActiveIndex}
+              delay={QUERY_DELAY}
+              delayFunction={(status: string) =>
+                tableRef.current?.setColumnFilter("is_public", () => (status === "All" ? [] : [status.toLowerCase()]))
+              }
             />
           </div>
+          {(searchQuery !== "" ||
+            statusActiveIndex !== 0 ||
+            conditionActiveIndex !== 0 ||
+            visibilityActiveIndex !== 0) && (
+            <button
+              type="button"
+              className="self-end flex items-center gap-x-1 px-2 md:px-3 py-2 bg-transparent text-text-muted font-medium rounded-2xl hover:bg-black/5 transition-colors duration-100"
+              onClick={resetFilters}
+            >
+              <X className="w-4 h-4" />
+              <span className="text-sm lg:text-md">Clear Filters</span>
+            </button>
+          )}
         </div>
+
+        <Select
+          className="hidden md:block"
+          label="Columns"
+          tableRef={tableRef}
+          checkedIcon={<Check />}
+          onCheckedItem={(item: string) => tableRef.current?.setColumnVisibility(item, (visible) => !visible)}
+        />
       </div>
     </div>
   );

--- a/src/components/TreePageTableWidget.tsx
+++ b/src/components/TreePageTableWidget.tsx
@@ -42,7 +42,7 @@ function TreePageTableWidget({
   }, []);
 
   return (
-    <div className={`min-w-0 flex flex-col overflow-hidden ${className || ""}`}>
+    <div className={`min-w-0 flex flex-col ${className || ""}`}>
       <div className="flex-1 min-h-0 min-w-0 flex flex-col">
         {error ? (
           <div className="w-full h-full flex justify-center items-center text-red-500">{error}</div>

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -2,10 +2,10 @@ type BadgeVariant = "default" | "muted" | "warning" | "destructive";
 type IconSide = "left" | "right";
 
 const badgeVariantClasses: Record<BadgeVariant, string> = {
-  default: "text-primary bg-primary/15 border border-primary/20",
-  muted: "text-text-muted bg-text-muted/15 border border-text-muted/20",
-  warning: "text-warning bg-warning/15 border border-warning/20",
-  destructive: "text-destructive bg-destructive/15 border border-destructive/20",
+  default: "text-primary bg-primary/25 border border-primary/30",
+  muted: "text-text-muted bg-text-muted/20 border border-text-muted/25",
+  warning: "text-warning bg-warning/15 border border-warning/30",
+  destructive: "text-destructive bg-destructive/15 border border-destructive/25",
 };
 
 export default function Badge({

--- a/src/components/data-table/head-controls.tsx
+++ b/src/components/data-table/head-controls.tsx
@@ -24,7 +24,7 @@ export default function HeadControls({ table, columnId, title, canHide = true, c
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger
-        className={`cursor-pointer select-none px-2 py-1.5 flex gap-x-2 items-center text-text-dark rounded-lg hover:bg-text-muted/15 transition-colors duration-50 ${isOpen && "bg-text-muted/15"}`}
+        className={`cursor-pointer select-none px-2 py-1.5 flex gap-x-2 items-center text-text-dark rounded-lg hover:bg-text-muted/15 transition-colors duration-100 ${isOpen && "bg-text-muted/15"}`}
       >
         <span>{title}</span>
         {canSort ? <ArrowUpDown className="w-3 h-3 text-text-muted" /> : <EyeOff className="w-3 h-3 text-text-muted" />}

--- a/src/components/data-table/pagination-controls.tsx
+++ b/src/components/data-table/pagination-controls.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../dropdown-menu";
 import { Table } from "./table/table-types";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
 
 export default function PaginationControls<T extends Record<string, unknown>>({ table }: { table: Table<T> }) {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -9,9 +9,11 @@ export default function PaginationControls<T extends Record<string, unknown>>({ 
   return (
     <div className="w-full h-full flex justify-between items-center px-6">
       <div className="flex gap-2 items-center">
-        <p className="text-text-dark font-medium">Rows per page:</p>
+        <p className="text-text-dark font-medium">
+          Rows<span className="hidden lg:inline"> per page</span>:
+        </p>
         <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-          <DropdownMenuTrigger className="w-20 px-3 py-1 flex justify-between items-center bg-button-light border border-border text-text-dark rounded-xl hover:bg-button-light/80 transition-colors duration-50">
+          <DropdownMenuTrigger className="w-16 lg:w-20 px-2 lg:px-3 py-1 flex justify-between items-center bg-button-light border border-border text-text-dark rounded-xl hover:bg-button-light/80 transition-colors duration-50">
             <span>{table.getPageSize()}</span>
             <ChevronDown
               className={`w-4 h-4 text-text-muted transition-transform duration-200 ${isOpen && "rotate-180"}`}
@@ -35,29 +37,34 @@ export default function PaginationControls<T extends Record<string, unknown>>({ 
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-        <p className="text-text-muted">
-          Showing <span>{table.getPageIndex() * table.getPageSize() + 1}</span> to{" "}
+        <p className="shrink-0 text-text-muted">
+          <span className="hidden lg:inline">Showing </span>
+          <span>{table.getPageIndex() * table.getPageSize() + 1}</span> to{" "}
           <span>{Math.min((table.getPageIndex() + 1) * table.getPageSize(), table.getUnpaginatedRowCount())}</span> of{" "}
-          <span>{table.getUnpaginatedRowCount()}</span> trees
+          <span>{table.getUnpaginatedRowCount()}</span>
+          <span> trees</span>
         </p>
       </div>
-      <div className="flex gap-4 items-center">
+      <div className="flex gap-2 lg:gap-4 items-center">
         <button
-          className="px-3 py-1 bg-button border border-border text-text-dark rounded-xl hover:bg-button/80 disabled:opacity-60 disabled:cursor-not-allowed"
+          className="px-2 py-2 lg:px-3 lg:py-1 bg-button border border-border text-text-dark rounded-xl hover:bg-button/80 disabled:opacity-60 disabled:cursor-not-allowed"
           disabled={!table.hasPreviousPage()}
           onClick={table.previousPage}
         >
-          Previous
+          <ChevronLeft className="w-4 h-4 lg:hidden" />
+          <span className="hidden lg:inline">Previous</span>
         </button>
-        <p className="text-text-dark">
-          Page <span>{table.getPageIndex() + 1}</span> of <span>{table.getPageCount()}</span>
+        <p className="shrink-0 text-text-dark">
+          <span className="hidden lg:inline">Page </span>
+          <span>{table.getPageIndex() + 1}</span> of <span>{table.getPageCount()}</span>
         </p>
         <button
-          className="px-3 py-1 bg-button border border-border text-text-dark rounded-xl hover:bg-button/80 disabled:opacity-60 disabled:cursor-not-allowed"
+          className="px-2 py-2 lg:px-3 lg:py-1 bg-button border border-border text-text-dark rounded-xl hover:bg-button/80 disabled:opacity-60 disabled:cursor-not-allowed"
           disabled={!table.hasNextPage()}
           onClick={table.nextPage}
         >
-          Next
+          <span className="hidden lg:inline">Next</span>
+          <ChevronRight className="w-4 h-4 lg:hidden" />
         </button>
       </div>
     </div>

--- a/src/components/data-table/table-widget-defs.tsx
+++ b/src/components/data-table/table-widget-defs.tsx
@@ -185,7 +185,7 @@ export const treeColumns: ColumnDef<TreeSchema>[] = [
     head: (table, name, columnId) => <HeadControls table={table} columnId={columnId} title={name} />,
     cell: (value) => (
       <Badge variant={value ? "default" : "muted"} className="capitalize">
-        {value ? "True" : "False"}
+        {value ? "Public" : "Private"}
       </Badge>
     ),
     cellId: (value) => {

--- a/src/components/data-table/table/table-types.ts
+++ b/src/components/data-table/table/table-types.ts
@@ -265,9 +265,18 @@ export const useTable = <T extends Record<string, unknown>>(
     return pageSize;
   }, [pageSize]);
 
-  const setPageSizeSafe = React.useCallback((size: number) => {
-    if (size > 0) setPageSize(size);
-  }, []);
+  const setPageSizeSafe = React.useCallback(
+    (size: number) => {
+      if (size <= 0) return;
+
+      const nextPageCount = Math.ceil(sortedRows.length / size);
+      const maxPageIndex = Math.max(0, nextPageCount - 1);
+
+      setPageSize(size);
+      setPageIndex((prev) => Math.min(prev, maxPageIndex));
+    },
+    [sortedRows.length, setPageSize, setPageIndex],
+  );
 
   const getPageIndex = React.useCallback(() => {
     return pageIndex;

--- a/src/components/data-table/table/table-types.ts
+++ b/src/components/data-table/table/table-types.ts
@@ -55,6 +55,7 @@ export type Table<T extends Record<string, unknown>> = {
   getCell: (column: ColumnDef<T>, value: CellValue<T>, row: T) => React.ReactNode;
   getColumnSorting: () => SortingState;
   setColumnSorting: (columnId: string, desc: boolean) => void;
+  getColumnVisibility: (columnId: string) => boolean;
   setColumnVisibility: (columnId: string, update: (prev: boolean) => boolean) => void;
   getColumnFilterValue: (columnId: string) => string[];
   setColumnFilter: (columnId: string, update: (prev: string[]) => string[]) => void;
@@ -211,6 +212,13 @@ export const useTable = <T extends Record<string, unknown>>(
     setSorting({ id: columnId, desc });
   }, []);
 
+  const getColumnVisibility = React.useCallback(
+    (columnId: string) => {
+      return columnVisibility[columnId] ?? true;
+    },
+    [columnVisibility],
+  );
+
   const setColumnVisibilityValue = React.useCallback((columnId: string, update: (prev: boolean) => boolean) => {
     setColumnVisibility((prev) => ({ ...prev, [columnId]: update(prev[columnId] ?? true) }));
   }, []);
@@ -304,6 +312,7 @@ export const useTable = <T extends Record<string, unknown>>(
       getCell,
       getColumnSorting,
       setColumnSorting,
+      getColumnVisibility,
       setColumnVisibility: setColumnVisibilityValue,
       getColumnFilterValue,
       setColumnFilter,
@@ -332,6 +341,7 @@ export const useTable = <T extends Record<string, unknown>>(
     getCell,
     getColumnSorting,
     setColumnSorting,
+    getColumnVisibility,
     setColumnVisibilityValue,
     getColumnFilterValue,
     setColumnFilter,

--- a/src/components/data-table/table/table.tsx
+++ b/src/components/data-table/table/table.tsx
@@ -18,9 +18,7 @@ export default function Table({
   children,
 }: TableProps) {
   return (
-    <div
-      className={`min-h-0 min-w-0 max-w-full border border-border rounded-xl overflow-hidden flex flex-col ${className || ""}`}
-    >
+    <div className={`min-h-0 min-w-0 max-w-full border border-border overflow-hidden flex flex-col ${className || ""}`}>
       <div className="min-h-0 min-w-0 max-w-full overflow-auto">
         <table className={`border-collapse w-max min-w-full ${tableClassName || ""}`}>{children}</table>
       </div>

--- a/src/components/data-table/tree-dashboard-table.tsx
+++ b/src/components/data-table/tree-dashboard-table.tsx
@@ -49,7 +49,7 @@ function TreeDashboardTable({
   );
 
   return (
-    <Table className={className} tableClassName="bg-table-row-light text-text-dark">
+    <Table className={className} tableClassName="bg-table-row-light text-text-dark rounded-xl shadow-sm">
       <TableHeader className="bg-table-header">
         <TableRow>
           {table.getColumns().map((col, i) => (

--- a/src/components/data-table/tree-page-table.tsx
+++ b/src/components/data-table/tree-page-table.tsx
@@ -60,7 +60,7 @@ function TreePageTable({
 
   return (
     <Table
-      className={className}
+      className={`${className} rounded-xl shadow-sm`}
       tableClassName="bg-table-row-light text-text-dark"
       footer={true}
       footerClassName="bg-table-header h-16"

--- a/src/components/data-table/tree-page-table.tsx
+++ b/src/components/data-table/tree-page-table.tsx
@@ -29,7 +29,6 @@ function TreePageTable({
 
   const columns = table.getColumns();
   const rowModels = table.getRowModels();
-  const placeholderRowCount = Math.max(table.getPageSize() - rowModels.length, 0);
 
   const renderPlaceholderRows = React.useCallback(
     (count: number, startIndex: number) => {
@@ -83,7 +82,7 @@ function TreePageTable({
                 <p className="sticky left-1/2 -translate-x-1/2 w-max">Loading trees...</p>
               </TableCell>
             </TableRow>
-            {renderPlaceholderRows(Math.max(placeholderRowCount - 1, 0), 1)}
+            {renderPlaceholderRows(4, 1)}
           </>
         ) : rowModels.length ? (
           <>
@@ -106,7 +105,6 @@ function TreePageTable({
                 ))}
               </TableRow>
             ))}
-            {renderPlaceholderRows(placeholderRowCount, rowModels.length)}
           </>
         ) : (
           <>
@@ -115,7 +113,7 @@ function TreePageTable({
                 <p className="sticky left-1/2 -translate-x-1/2 w-max">No results.</p>
               </TableCell>
             </TableRow>
-            {renderPlaceholderRows(Math.max(placeholderRowCount - 1, 0), 1)}
+            {renderPlaceholderRows(4, 1)}
           </>
         )}
       </TableBody>

--- a/src/components/dropdown-menu.tsx
+++ b/src/components/dropdown-menu.tsx
@@ -51,6 +51,13 @@ type DropdownMenuItemProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   inset?: boolean;
 };
 
+type DropdownMenuCheckboxItemProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> & {
+  checked: boolean;
+  checkedIcon?: ReactNode;
+  inset?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+};
+
 const DropdownMenuContext = createContext<DropdownMenuContextValue | null>(null);
 
 function assignRef<T>(ref: Ref<T> | undefined, node: T | null) {
@@ -414,6 +421,67 @@ const DropdownMenuItem = forwardRef<HTMLButtonElement, DropdownMenuItemProps>(fu
   );
 });
 
+const DropdownMenuCheckboxItem = forwardRef<HTMLButtonElement, DropdownMenuCheckboxItemProps>(
+  function DropdownMenuCheckboxItem(
+    { checked, checkedIcon, className, inset, onCheckedChange, onClick, onKeyDown, disabled, children, ...props },
+    forwardedRef,
+  ) {
+    const { isKeyboardNavigation, setIsKeyboardNavigation } = useDropdownMenuContext("DropdownMenuCheckboxItem");
+    const handleItemClick = useCallback(
+      (event: ReactMouseEvent<HTMLButtonElement>) => {
+        onClick?.(event);
+
+        if (event.defaultPrevented || disabled) return;
+        setIsKeyboardNavigation(false);
+        onCheckedChange?.(!checked);
+      },
+      [checked, disabled, onCheckedChange, onClick, setIsKeyboardNavigation],
+    );
+    const handleItemKeyDown = useCallback(
+      (event: KeyboardEvent<HTMLButtonElement>) => {
+        onKeyDown?.(event);
+
+        if (event.defaultPrevented) return;
+        if (!["Enter", " "].includes(event.key)) return;
+
+        event.preventDefault();
+        setIsKeyboardNavigation(true);
+        event.currentTarget.click();
+      },
+      [onKeyDown, setIsKeyboardNavigation],
+    );
+
+    return (
+      <button
+        ref={forwardedRef}
+        type="button"
+        role="menuitemcheckbox"
+        aria-checked={checked}
+        data-disabled={disabled ? "true" : "false"}
+        data-dropdown-menu-item="true"
+        data-state={checked ? "checked" : "unchecked"}
+        disabled={disabled}
+        className={cn(
+          "relative flex w-full cursor-default select-none items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm outline-none transition-colors",
+          "hover:bg-primary hover:text-text-light disabled:pointer-events-none disabled:opacity-50",
+          isKeyboardNavigation && "focus:bg-primary focus:text-text-light",
+          inset && "pl-8",
+          className,
+        )}
+        onClick={handleItemClick}
+        onKeyDown={handleItemKeyDown}
+        onPointerMove={() => setIsKeyboardNavigation(false)}
+        {...props}
+      >
+        <span aria-hidden="true" className="flex h-4 w-4 shrink-0 items-center justify-center">
+          {checked ? checkedIcon : null}
+        </span>
+        <span className="flex-1">{children}</span>
+      </button>
+    );
+  },
+);
+
 const DropdownMenuSeparator = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(function DropdownMenuSeparator(
   { className, ...props },
   forwardedRef,
@@ -425,6 +493,14 @@ DropdownMenu.displayName = "DropdownMenu";
 DropdownMenuTrigger.displayName = "DropdownMenuTrigger";
 DropdownMenuContent.displayName = "DropdownMenuContent";
 DropdownMenuItem.displayName = "DropdownMenuItem";
+DropdownMenuCheckboxItem.displayName = "DropdownMenuCheckboxItem";
 DropdownMenuSeparator.displayName = "DropdownMenuSeparator";
 
-export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator };
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuSeparator,
+};


### PR DESCRIPTION
## Developer: Will Heath

Closes #103 

### Pull Request Summary

Added column visibility controls and made the trees page relatively responsive and mobile friendly.

Note the survey_logs column is not properly implemented because I am unsure if that should even be rendered as they are just foreign keys, and if so, what should be there. Also the add tree button has no functionallity. I believe this links to someone elses component.

### Modifications

Added Column visibility dropdown with toggles for every columns visibility and an enable all button. Improved all UI trees page UI to respond relatively well to Window size changes.
Added a Clear filters button that appears when filters are applied.

### Testing Considerations

Everything seems to work with a variety of filters and columns enabled.
Page responds to window size changes without obscuring buttons.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="3414" height="1792" alt="Screenshot 2026-04-22 210249" src="https://github.com/user-attachments/assets/23b53b6b-3fc0-4ee0-aff9-aa0f39ed9eee" />

    
<img width="1262" height="1732" alt="Screenshot 2026-04-22 210400" src="https://github.com/user-attachments/assets/d56c6c3f-f641-4e50-ba92-6d7d6e5015f3" />
