### PR TITLE
Survey Notes & Tree Popout click

### DIFF
--- a/src/app/(admin)/trees/page.tsx
+++ b/src/app/(admin)/trees/page.tsx
@@ -20,6 +20,7 @@ export default function Trees() {
           key={currentTree != null ? String(currentTree.id) : "closed"}
           admin={true}
           tree={currentTree != null ? currentTree : undefined}
+          onClose={() => setCurrentTree(null)}
         />
       </div>
       <div className="flex flex-col gap-y-8 px-6 py-10">

--- a/src/components/TreeDetailsPopout.tsx
+++ b/src/components/TreeDetailsPopout.tsx
@@ -174,7 +174,10 @@ export default function TreeDetailsPopout(props: treeDetailsPopoutProps) {
     { title: "Yearly Mulching Status:", info: display(source.yearly_mulching_status) },
   ];
   return (
-    <div className="fixed inset-0 z-[3000] flex items-center justify-center bg-black/40 p-6">
+    <div
+      className="fixed inset-0 z-[3000] flex items-center justify-center bg-black/40 p-6"
+      onClick={(e) => e.stopPropagation()}
+    >
       <div className="flex w-[620px] max-h-[88vh] max-w-full flex-col items-center overflow-hidden rounded-2xl bg-[#f4ede2] p-[32px] pb-[0px] drop-shadow-xl">
         {/* Header */}
         <div className="flex flex-col items-center">
@@ -232,6 +235,10 @@ export default function TreeDetailsPopout(props: treeDetailsPopoutProps) {
                       <p>Other: {display(body.issueOther)}</p>
                       <p>Image Link: {display(body.imageLink)}</p>
                       <p>Admin Contact: {display(body.adminContact)}</p>
+                      <div className="mt-1 max-h-40 overflow-y-auto whitespace-pre-wrap break-words">
+                        <p className="font-semibold text-black/80">Survey notes</p>
+                        <p>{display(body.notes)}</p>
+                      </div>
                     </div>
                   );
                 })}

--- a/src/components/TreeDetailsPopout.tsx
+++ b/src/components/TreeDetailsPopout.tsx
@@ -2,11 +2,13 @@
 import { TreeSchema } from "@/components/data-table/table-widget-defs";
 import { Tables } from "@/database/database.types";
 import { supabase } from "@/supabase-client";
+import { X } from "lucide-react";
 import { useEffect, useState } from "react";
 
 type treeDetailsPopoutProps = {
   tree?: TreeSchema;
   admin: boolean;
+  onClose?: () => void;
 };
 
 type Member = Tables<"members">;
@@ -178,7 +180,20 @@ export default function TreeDetailsPopout(props: treeDetailsPopoutProps) {
       className="fixed inset-0 z-[3000] flex items-center justify-center bg-black/40 p-6"
       onClick={(e) => e.stopPropagation()}
     >
-      <div className="flex w-[620px] max-h-[88vh] max-w-full flex-col items-center overflow-hidden rounded-2xl bg-[#f4ede2] p-[32px] pb-[0px] drop-shadow-xl">
+      <div className="relative flex w-[620px] max-h-[88vh] max-w-full flex-col items-center overflow-hidden rounded-2xl bg-[#f4ede2] p-[32px] pb-[0px] drop-shadow-xl">
+        {props.onClose ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              props.onClose?.();
+            }}
+            className="absolute top-3 right-3 inline-flex h-8 w-8 items-center justify-center rounded-full border border-black/20 bg-white/90 text-neutral-700 shadow-sm transition hover:bg-white hover:text-neutral-900"
+            aria-label="Close tree details"
+          >
+            <X className="h-4 w-4" strokeWidth={2} />
+          </button>
+        ) : null}
         {/* Header */}
         <div className="flex flex-col items-center">
           <h1 className="text-[32px] font-serif">#{source.ecoslo_num} Tree Details</h1>

--- a/src/components/survey/SurveyForm.tsx
+++ b/src/components/survey/SurveyForm.tsx
@@ -9,10 +9,12 @@ import {
 } from "@/types/survey";
 import { useCallback, useEffect, useState } from "react";
 import AdminContactSection from "./AdminContactSection";
+import FormSection from "./FormSection";
 import ImageLinkSection from "./ImageLinkSection";
 import IssueSection from "./IssueSection";
 import TaskSelectSection from "./TaskSelectSection";
 import TreeSelectSection from "./TreeSelectSection";
+import { surveyFieldClass, surveyLabelClass } from "./formStyles";
 
 const DEFAULT_ISSUE: SurveyIssueValue = "watering";
 
@@ -37,6 +39,7 @@ export default function SurveyForm() {
   const [issue, setIssueState] = useState<SurveyIssueValue>(DEFAULT_ISSUE);
   const [issueOther, setIssueOther] = useState("");
   const [imageLink, setImageLink] = useState("");
+  const [notes, setNotes] = useState("");
   const [adminContact, setAdminContact] = useState(false);
 
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -100,6 +103,7 @@ export default function SurveyForm() {
       issueOther,
       imageLink,
       adminContact,
+      notes,
     });
 
     const payload = {
@@ -170,6 +174,23 @@ export default function SurveyForm() {
       />
 
       <ImageLinkSection value={imageLink} onChange={setImageLink} disabled={submitting} error={fieldErrors.imageLink} />
+
+      <FormSection title="Notes" titleId="survey-heading-notes">
+        <div>
+          <label htmlFor="survey-notes" className={surveyLabelClass}>
+            Additional information (optional)
+          </label>
+          <textarea
+            id="survey-notes"
+            rows={6}
+            className={`${surveyFieldClass} min-h-[140px] resize-y`}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            disabled={submitting}
+            placeholder="Anything else we should know…"
+          />
+        </div>
+      </FormSection>
 
       <AdminContactSection value={adminContact} onChange={setAdminContact} disabled={submitting} />
 

--- a/src/types/survey.ts
+++ b/src/types/survey.ts
@@ -24,6 +24,8 @@ export type SurveyBodyPayload = {
   /** URL string only; binary images are not stored. */
   imageLink: string;
   adminContact: boolean;
+  /** Free-form notes from the submitter (may be long). */
+  notes: string;
 };
 
 export const SURVEY_ISSUE_OPTIONS = [
@@ -51,6 +53,7 @@ export function buildSurveyBodyPayload(input: {
   issueOther: string;
   imageLink: string;
   adminContact: boolean;
+  notes: string;
 }): SurveyBodyPayload {
   const other = input.issueOther.trim();
   return {
@@ -58,6 +61,7 @@ export function buildSurveyBodyPayload(input: {
     ...(input.issue === "other" && other ? { issueOther: other } : {}),
     imageLink: input.imageLink.trim(),
     adminContact: input.adminContact,
+    notes: input.notes.trim(),
   };
 }
 


### PR DESCRIPTION
## Developer: Mohini Chahal 

Closes #119'

### Pull Request Summary

Users can add optional Notes in the survey form; those notes are stored in surveys.body as notes and are shown when viewing linked surveys in the tree details popout. The popout no longer closes when clicking inside it (so text can be selected/copied), and a small Close control was added for an explicit dismiss action.
### Modifications

trees/page.tsx
treedetailspopout.tsx
surveyform.tsx 
survey.ts

### Testing Considerations

The Tree View only closes when clicking the close button on the top right of the card. The Survey form has an additional notes section which is also displayed in the body of the tree popout.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
