### PR TITLE
Implements automated Reminder system

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
-  }
+  },
+  "deno.enable": true,
+  "deno.enablePaths": ["./supabase/functions"],
+  "deno.unstable": false
 }

--- a/src/components/reminders/ReminderView.tsx
+++ b/src/components/reminders/ReminderView.tsx
@@ -16,7 +16,7 @@ type Member = Tables<"members">;
 type Reminder = Tables<"reminders">;
 type Template = Tables<"templates">;
 type ReminderWithNeedsSurvey = Reminder & { needs_survey?: boolean | null };
-type ReminderInsertPayload = TablesInsert<"reminders"> & { needs_survey?: boolean }; // TODO: update database types for needs_survey
+type ReminderInsertPayload = TablesInsert<"reminders"> & { needs_survey?: boolean };
 type ReminderUpdatePayload = TablesUpdate<"reminders"> & { needs_survey?: boolean };
 const MEMBER_TYPES = ["Admin", "Tree Keeper"] as const satisfies readonly MemberEnum[];
 
@@ -385,15 +385,17 @@ function getReminderPayload(form: ReminderFormState): ReminderInsertPayload {
   }
 
   const assignees = getSelectedAssigneeIds(form.assignees);
+  const crons_expression = getCronExpressionFromForm(form);
 
   return {
     assignees,
-    crons_expression: getCronExpressionFromForm(form),
+    crons_expression: crons_expression,
     is_active: form.isActive,
     is_group_task: assignees.length > 1,
     needs_survey: form.needsSurvey,
     name: form.name.trim(),
     task_message: form.message,
+    next_run_at: getNextCronOccurrence(crons_expression).toISOString(),
   };
 }
 

--- a/src/database/database.types.ts
+++ b/src/database/database.types.ts
@@ -55,8 +55,10 @@ export type Database = {
           id: number;
           is_active: boolean;
           is_group_task: boolean;
+          last_run_at: string | null;
           name: string;
           needs_survey: boolean;
+          next_run_at: string;
           task_message: string;
         };
         Insert: {
@@ -66,8 +68,10 @@ export type Database = {
           id?: number;
           is_active?: boolean;
           is_group_task?: boolean;
+          last_run_at?: string | null;
           name?: string;
           needs_survey?: boolean;
+          next_run_at: string;
           task_message?: string;
         };
         Update: {
@@ -77,8 +81,10 @@ export type Database = {
           id?: number;
           is_active?: boolean;
           is_group_task?: boolean;
+          last_run_at?: string | null;
           name?: string;
           needs_survey?: boolean;
+          next_run_at?: string;
           task_message?: string;
         };
         Relationships: [];
@@ -128,9 +134,13 @@ export type Database = {
           completion_date: string | null;
           created_at: string;
           created_by: number | null;
+          email_attempts: number;
+          email_last_error: string | null;
+          email_sent_at: string | null;
           id: number;
           is_complete: boolean;
           message: string;
+          reminder_id: number | null;
           surveys_needed: number;
           title: string;
         };
@@ -139,9 +149,13 @@ export type Database = {
           completion_date?: string | null;
           created_at?: string;
           created_by?: number | null;
+          email_attempts?: number;
+          email_last_error?: string | null;
+          email_sent_at?: string | null;
           id?: number;
           is_complete?: boolean;
           message: string;
+          reminder_id?: number | null;
           surveys_needed?: number;
           title?: string;
         };
@@ -150,9 +164,13 @@ export type Database = {
           completion_date?: string | null;
           created_at?: string;
           created_by?: number | null;
+          email_attempts?: number;
+          email_last_error?: string | null;
+          email_sent_at?: string | null;
           id?: number;
           is_complete?: boolean;
           message?: string;
+          reminder_id?: number | null;
           surveys_needed?: number;
           title?: string;
         };
@@ -162,6 +180,13 @@ export type Database = {
             columns: ["created_by"];
             isOneToOne: false;
             referencedRelation: "members";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "tasks_reminder_id_fkey";
+            columns: ["reminder_id"];
+            isOneToOne: false;
+            referencedRelation: "reminders";
             referencedColumns: ["id"];
           },
         ];
@@ -299,7 +324,26 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
-      [_ in never]: never;
+      fire_reminder: {
+        Args: { p_next_run_at: string; p_reminder_id: number };
+        Returns: undefined;
+      };
+      get_pending_email_jobs: {
+        Args: { p_limit?: number };
+        Returns: {
+          assignee_id: number;
+          email_attempts: number;
+          member_email: string;
+          member_firstname: string;
+          task_id: number;
+          task_message: string;
+          task_title: string;
+        }[];
+      };
+      increment_email_attempts: {
+        Args: { p_error: string; p_task_ids: number[] };
+        Returns: undefined;
+      };
     };
     Enums: {
       Condition: "good" | "fair" | "poor";

--- a/src/lib/cron_utils.ts
+++ b/src/lib/cron_utils.ts
@@ -48,6 +48,65 @@ const MONTH_NAMES = [
 ] as const;
 const DEFAULT_TIME: CronTimeInput = { hour: 8, minute: 0 };
 
+/**
+ * All cron evaluation is anchored to Pacific time so that schedules behave
+ * identically regardless of where this code runs (browser in any timezone,
+ * Vercel server in UTC, Supabase Edge Function in UTC, local dev in PST/PDT).
+ */
+const PACIFIC_TZ = "America/Los_Angeles";
+
+// Cached at module scope; constructing a DateTimeFormat is non-trivial.
+const PACIFIC_PARTS_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  timeZone: PACIFIC_TZ,
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  weekday: "short",
+  hourCycle: "h23",
+});
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+type PacificFields = {
+  minute: number;
+  hour: number;
+  dayOfMonth: number;
+  month: number;
+  dayOfWeek: number;
+};
+
+/**
+ * Returns the wall-clock fields of `date` as they appear in Pacific time.
+ * Handles DST automatically via the IANA database. Use this instead of
+ * `Date.prototype.getHours()` etc., which return values based on the
+ * runtime's local timezone.
+ */
+function getPacificFields(date: Date): PacificFields {
+  const parts = PACIFIC_PARTS_FORMATTER.formatToParts(date);
+  const get = (type: string): string => {
+    const part = parts.find((p) => p.type === type);
+    if (!part) throw new Error(`Missing Intl part: ${type}`);
+    return part.value;
+  };
+  return {
+    minute: parseInt(get("minute"), 10),
+    hour: parseInt(get("hour"), 10),
+    dayOfMonth: parseInt(get("day"), 10),
+    month: parseInt(get("month"), 10),
+    dayOfWeek: WEEKDAY_INDEX[get("weekday")],
+  };
+}
+
 type ParsedDayToken =
   | { type: "single"; value: number }
   | { type: "list"; values: number[] }
@@ -236,21 +295,6 @@ function parseStepToken(token: string): { base: string; step: number } | null {
   return base && rawStep && isInteger(rawStep) ? { base, step: Number(rawStep) } : null;
 }
 
-function getFieldValueForDate(field: CronFieldName, date: Date): number {
-  switch (field) {
-    case "minute":
-      return date.getMinutes();
-    case "hour":
-      return date.getHours();
-    case "dayOfMonth":
-      return date.getDate();
-    case "month":
-      return date.getMonth() + 1;
-    case "dayOfWeek":
-      return date.getDay();
-  }
-}
-
 function expandCronToken(field: CronFieldName, token: string): number[] | null {
   const { min, max, names } = FIELD_CONFIG[field];
 
@@ -304,14 +348,19 @@ function matchesCronField(field: CronFieldName, token: string, value: number): b
 }
 
 function matchesCronDate(parts: CronParts, date: Date): boolean {
-  const minuteMatches = matchesCronField("minute", parts.minute, getFieldValueForDate("minute", date));
-  const hourMatches = matchesCronField("hour", parts.hour, getFieldValueForDate("hour", date));
-  const monthMatches = matchesCronField("month", parts.month, getFieldValueForDate("month", date));
+  // Read all wall-clock fields once in Pacific time. Using
+  // getPacificFields here is what makes cron evaluation timezone-correct
+  // when this runs on a non-Pacific host (Vercel/UTC, Supabase/UTC).
+  const fields = getPacificFields(date);
+
+  const minuteMatches = matchesCronField("minute", parts.minute, fields.minute);
+  const hourMatches = matchesCronField("hour", parts.hour, fields.hour);
+  const monthMatches = matchesCronField("month", parts.month, fields.month);
 
   if (!minuteMatches || !hourMatches || !monthMatches) return false;
 
-  const dayOfMonthMatches = matchesCronField("dayOfMonth", parts.dayOfMonth, getFieldValueForDate("dayOfMonth", date));
-  const dayOfWeekMatches = matchesCronField("dayOfWeek", parts.dayOfWeek, getFieldValueForDate("dayOfWeek", date));
+  const dayOfMonthMatches = matchesCronField("dayOfMonth", parts.dayOfMonth, fields.dayOfMonth);
+  const dayOfWeekMatches = matchesCronField("dayOfWeek", parts.dayOfWeek, fields.dayOfWeek);
   const restrictsDayOfMonth = !isWildcard(parts.dayOfMonth);
   const restrictsDayOfWeek = !isWildcard(parts.dayOfWeek);
 
@@ -412,19 +461,38 @@ export function parseCronExpression(expression: string): CronParts {
   return { minute, hour, dayOfMonth, month, dayOfWeek };
 }
 
-/** Returns the next local Date that matches a supported 5-field cron expression. */
+/**
+ * Returns the next Date strictly after `fromDate` whose Pacific wall-clock
+ * fields match the given 5-field cron expression.
+ *
+ * DST behavior in America/Los_Angeles:
+ * - Spring forward (1:59am PST → 3:00am PDT): wall-clock times in
+ *   2:00am–2:59am do not exist that day. A cron matching that range
+ *   skips the affected day and fires on the next valid occurrence.
+ * - Fall back (1:59am PDT → 1:00am PST): wall-clock times in 1:00am–1:59am
+ *   occur twice. A cron matching that range will fire at BOTH occurrences,
+ *   one hour apart in absolute time. For human-facing reminders this means
+ *   a once-yearly duplicate notification on the fall-back Sunday.
+ */
 export function getNextCronOccurrence(expression: string, fromDate: Date = new Date()): Date {
   const parts = parseCronExpression(expression);
-  const next = new Date(fromDate);
 
-  next.setSeconds(0, 0);
-  next.setMinutes(next.getMinutes() + 1);
+  // Floor to the start of the current UTC minute, then advance by one minute.
+  // Pure timestamp arithmetic only — we deliberately avoid Date methods like
+  // setSeconds/setMinutes here. Those operate on LOCAL fields, which has two
+  // problems: (a) on a UTC host, "local" means UTC and cron fields would not
+  // be interpreted in Pacific; (b) on a Pacific host, ambiguous local times
+  // during the fall-back hour cause setSeconds to silently shift the
+  // underlying timestamp by an hour.
+  let timestampMs = Math.floor(fromDate.getTime() / 60_000) * 60_000 + 60_000;
+  const next = new Date(timestampMs);
 
   const MAX_MINUTE_LOOKAHEAD = 60 * 24 * 366 * 5;
 
   for (let i = 0; i < MAX_MINUTE_LOOKAHEAD; i += 1) {
     if (matchesCronDate(parts, next)) return new Date(next);
-    next.setMinutes(next.getMinutes() + 1);
+    timestampMs += 60_000;
+    next.setTime(timestampMs);
   }
 
   throw new Error(`Could not find next occurrence for cron expression within 5 years: "${expression}"`);

--- a/supabase/functions/_shared/cron.ts
+++ b/supabase/functions/_shared/cron.ts
@@ -1,0 +1,286 @@
+/**
+ * Cron utilities for Supabase Edge Functions.
+ *
+ * A trimmed, timezone-aware port of `src/lib/cron_utils.ts`. Includes only
+ * what the scheduler needs: validating 5-field cron expressions, parsing
+ * them into named parts, and computing the next firing time.
+ *
+ * Date fields are interpreted in `America/Los_Angeles` regardless of the
+ * runtime's host timezone. Supabase Edge Functions run in UTC, so we cannot
+ * rely on `Date.prototype`'s local-time accessors here.
+ *
+ * The next-occurrence walk advances the underlying UTC timestamp directly
+ * (rather than via `setMinutes`) so behavior is identical in dev (Pacific)
+ * and production (UTC).
+ */
+
+export type CronParts = {
+  minute: string;
+  hour: string;
+  dayOfMonth: string;
+  month: string;
+  dayOfWeek: string;
+};
+
+type CronFieldName = keyof CronParts;
+type FieldConfig = { min: number; max: number; names?: readonly string[] };
+
+const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"] as const;
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+const FIELD_CONFIG: Record<CronFieldName, FieldConfig> = {
+  minute: { min: 0, max: 59 },
+  hour: { min: 0, max: 23 },
+  dayOfMonth: { min: 1, max: 31 },
+  month: { min: 1, max: 12, names: MONTH_NAMES },
+  dayOfWeek: { min: 0, max: 7, names: DAY_NAMES },
+};
+
+const PACIFIC_TZ = "America/Los_Angeles";
+
+// Cached at module scope; constructing a DateTimeFormat is non-trivial.
+const PACIFIC_PARTS_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  timeZone: PACIFIC_TZ,
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  weekday: "short",
+  hourCycle: "h23",
+});
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+type PacificFields = {
+  minute: number;
+  hour: number;
+  dayOfMonth: number;
+  month: number;
+  dayOfWeek: number;
+};
+
+/**
+ * Returns the wall-clock fields of `date` as they appear in Pacific time.
+ * Handles DST automatically via the IANA database.
+ */
+function getPacificFields(date: Date): PacificFields {
+  const parts = PACIFIC_PARTS_FORMATTER.formatToParts(date);
+  const get = (type: string): string => {
+    const part = parts.find((p) => p.type === type);
+    if (!part) throw new Error(`Missing Intl part: ${type}`);
+    return part.value;
+  };
+  return {
+    minute: parseInt(get("minute"), 10),
+    hour: parseInt(get("hour"), 10),
+    dayOfMonth: parseInt(get("day"), 10),
+    month: parseInt(get("month"), 10),
+    dayOfWeek: WEEKDAY_INDEX[get("weekday")],
+  };
+}
+
+function normalizeCronExpression(expression: string): string {
+  return expression.trim().replace(/\s+/g, " ");
+}
+
+function isInteger(value: string): boolean {
+  return /^\d+$/.test(value);
+}
+
+function normalizeNamedValue(value: string): string {
+  return value.slice(0, 3).toLowerCase();
+}
+
+function isNamedValue(value: string, names: readonly string[]): boolean {
+  return names.some((name) => normalizeNamedValue(name) === normalizeNamedValue(value));
+}
+
+function isValidCronValue(value: string, min: number, max: number, names?: readonly string[]): boolean {
+  if (isInteger(value)) {
+    const numericValue = Number(value);
+    return numericValue >= min && numericValue <= max;
+  }
+  return !!names && isNamedValue(value, names);
+}
+
+function isValidCronToken(token: string, min: number, max: number, names?: readonly string[]): boolean {
+  if (token === "*") return true;
+  if (token.includes("/")) {
+    const [base, step] = token.split("/");
+    return !!base && !!step && isInteger(step) && isValidCronToken(base, min, max, names);
+  }
+  if (token.includes(",")) return token.split(",").every((part) => isValidCronToken(part, min, max, names));
+  if (token.includes("-")) {
+    const [start, end] = token.split("-");
+    return isValidCronValue(start, min, max, names) && isValidCronValue(end, min, max, names);
+  }
+  return isValidCronValue(token, min, max, names);
+}
+
+function parseCronValue(value: string, names?: readonly string[]): number | null {
+  if (isInteger(value)) return Number(value);
+  if (!names) return null;
+  const index = names.findIndex((name) => normalizeNamedValue(name) === normalizeNamedValue(value));
+  if (index < 0) return null;
+  return names === DAY_NAMES ? index : index + 1;
+}
+
+function normalizeDayValue(value: number | null): number | null {
+  return value === 7 ? 0 : value;
+}
+
+function parseStepToken(token: string): { base: string; step: number } | null {
+  if (!token.includes("/")) return null;
+  const [base, rawStep] = token.split("/");
+  return base && rawStep && isInteger(rawStep) ? { base, step: Number(rawStep) } : null;
+}
+
+function expandCronToken(field: CronFieldName, token: string): number[] | null {
+  const { min, max, names } = FIELD_CONFIG[field];
+
+  if (token === "*") {
+    return Array.from({ length: max - min + 1 }, (_, index) => min + index);
+  }
+
+  if (token.includes(",")) {
+    return [...new Set(token.split(",").flatMap((part) => expandCronToken(field, part) ?? []))].sort((a, b) => a - b);
+  }
+
+  const stepToken = parseStepToken(token);
+  if (stepToken) {
+    const baseValues = expandCronToken(field, stepToken.base);
+    if (!baseValues?.length) return null;
+    const start = token.startsWith("*/") ? min : Math.min(...baseValues);
+    return baseValues.filter((value) => value >= start && (value - start) % stepToken.step === 0);
+  }
+
+  if (token.includes("-")) {
+    const [rawStart, rawEnd] = token.split("-");
+    const start = parseCronValue(rawStart, names);
+    const end = parseCronValue(rawEnd, names);
+
+    if (start === null || end === null) return null;
+    if (field === "dayOfWeek") {
+      const normalizedStart = normalizeDayValue(start);
+      const normalizedEnd = normalizeDayValue(end);
+      if (normalizedStart === null || normalizedEnd === null) return null;
+      if (normalizedStart <= normalizedEnd) {
+        return Array.from({ length: normalizedEnd - normalizedStart + 1 }, (_, index) => normalizedStart + index);
+      }
+      return [
+        ...Array.from({ length: 7 - normalizedStart }, (_, index) => normalizedStart + index),
+        ...Array.from({ length: normalizedEnd + 1 }, (_, index) => index),
+      ];
+    }
+
+    return Array.from({ length: end - start + 1 }, (_, index) => start + index);
+  }
+
+  const parsedValue = parseCronValue(token, names);
+  if (parsedValue === null) return null;
+  const normalizedValue = field === "dayOfWeek" ? normalizeDayValue(parsedValue) : parsedValue;
+  return normalizedValue === null ? null : [normalizedValue];
+}
+
+function matchesCronField(field: CronFieldName, token: string, value: number): boolean {
+  const allowedValues = expandCronToken(field, token);
+  return !!allowedValues?.includes(value);
+}
+
+function matchesCronDate(parts: CronParts, date: Date): boolean {
+  const fields = getPacificFields(date);
+
+  if (!matchesCronField("minute", parts.minute, fields.minute)) return false;
+  if (!matchesCronField("hour", parts.hour, fields.hour)) return false;
+  if (!matchesCronField("month", parts.month, fields.month)) return false;
+
+  const dayOfMonthMatches = matchesCronField("dayOfMonth", parts.dayOfMonth, fields.dayOfMonth);
+  const dayOfWeekMatches = matchesCronField("dayOfWeek", parts.dayOfWeek, fields.dayOfWeek);
+  const restrictsDayOfMonth = parts.dayOfMonth !== "*";
+  const restrictsDayOfWeek = parts.dayOfWeek !== "*";
+
+  // Cron convention: if both day-of-month and day-of-week are restricted,
+  // a date matches if EITHER is satisfied (logical OR).
+  if (restrictsDayOfMonth && restrictsDayOfWeek) {
+    return dayOfMonthMatches || dayOfWeekMatches;
+  }
+
+  return dayOfMonthMatches && dayOfWeekMatches;
+}
+
+/** Validates whether a string is a supported 5-field cron expression. */
+export function isValidFiveFieldCronExpression(expression: string): boolean {
+  const values = normalizeCronExpression(expression).split(" ");
+  if (values.length !== 5) return false;
+  return (Object.keys(FIELD_CONFIG) as CronFieldName[]).every((field, index) => {
+    const { min, max, names } = FIELD_CONFIG[field];
+    return isValidCronToken(values[index], min, max, names);
+  });
+}
+
+/** Parses a validated 5-field cron expression into its named fields. */
+export function parseCronExpression(expression: string): CronParts {
+  if (!isValidFiveFieldCronExpression(expression)) {
+    throw new Error(`Invalid 5-field cron expression: "${expression}"`);
+  }
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = normalizeCronExpression(expression).split(" ");
+  return { minute, hour, dayOfMonth, month, dayOfWeek };
+}
+
+/**
+ * Returns the next UTC Date strictly after `fromDate` whose Pacific
+ * wall-clock fields match the given 5-field cron expression.
+ *
+ * DST behavior in America/Los_Angeles:
+ * - Spring forward (1:59am PST → 3:00am PDT): wall-clock times in
+ *   2:00am–2:59am do not exist that day. A cron matching that range
+ *   skips the affected day and fires on the next valid occurrence.
+ * - Fall back (1:59am PDT → 1:00am PST): wall-clock times in 1:00am–1:59am
+ *   occur twice. A cron matching that range will fire at BOTH occurrences,
+ *   one hour apart in absolute time. For human-facing reminders this means
+ *   a once-yearly duplicate notification on the fall-back Sunday.
+ */
+export function getNextCronOccurrence(expression: string, fromDate: Date = new Date()): Date {
+  const parts = parseCronExpression(expression);
+
+  // Floor to the start of the current UTC minute, then advance by one minute.
+  // Pure timestamp arithmetic only — we deliberately avoid Date methods like
+  // setSeconds/setMinutes here. Those operate on LOCAL fields, which causes
+  // ambiguous-time bugs during the fall-back hour in Pacific runtime, and
+  // wrong-timezone interpretation in UTC runtime.
+  let timestampMs = Math.floor(fromDate.getTime() / 60_000) * 60_000 + 60_000;
+  const next = new Date(timestampMs);
+
+  const MAX_MINUTE_LOOKAHEAD = 60 * 24 * 366 * 5;
+
+  for (let i = 0; i < MAX_MINUTE_LOOKAHEAD; i += 1) {
+    if (matchesCronDate(parts, next)) return new Date(next);
+    timestampMs += 60_000;
+    next.setTime(timestampMs);
+  }
+
+  throw new Error(`Could not find next occurrence for cron expression within 5 years: "${expression}"`);
+}

--- a/supabase/functions/_shared/emails/TaskEmail.tsx
+++ b/supabase/functions/_shared/emails/TaskEmail.tsx
@@ -1,0 +1,99 @@
+import { Body, Container, Head, Heading, Hr, Html, Preview, Section, Text } from "npm:@react-email/components@0.0.36";
+import * as React from "npm:react@19.0.0";
+
+export type TaskEmailProps = {
+  firstname: string;
+  title: string;
+  message: string;
+};
+
+export function TaskEmail({ firstname, title, message }: TaskEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>New task: {title}</Preview>
+      <Body style={bodyStyle}>
+        <Container style={containerStyle}>
+          <Heading as="h2" style={headingStyle}>
+            Hi {firstname},
+          </Heading>
+          <Text style={textStyle}>You have a new task:</Text>
+          <Section style={taskCardStyle}>
+            <Heading as="h3" style={taskTitleStyle}>
+              {title}
+            </Heading>
+            <Text style={taskMessageStyle}>{message}</Text>
+          </Section>
+          <Hr style={hrStyle} />
+          <Text style={footerStyle}>This is an automated reminder from ECOSLO.</Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+// Inline styles because many email clients (Gmail, Outlook)
+// strip <style> tags or don't honor external CSS.
+const bodyStyle: React.CSSProperties = {
+  backgroundColor: "#f6f9fc",
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  margin: 0,
+  padding: 0,
+};
+
+const containerStyle: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  margin: "40px auto",
+  padding: "32px",
+  maxWidth: "560px",
+  borderRadius: "8px",
+};
+
+const headingStyle: React.CSSProperties = {
+  color: "#1a1a1a",
+  fontSize: "20px",
+  fontWeight: 600,
+  marginTop: 0,
+  marginBottom: "16px",
+};
+
+const textStyle: React.CSSProperties = {
+  color: "#404040",
+  fontSize: "15px",
+  lineHeight: "24px",
+};
+
+const taskCardStyle: React.CSSProperties = {
+  backgroundColor: "#f6f9fc",
+  border: "1px solid #e6ebf1",
+  borderRadius: "6px",
+  padding: "20px",
+  margin: "20px 0",
+};
+
+const taskTitleStyle: React.CSSProperties = {
+  color: "#1a1a1a",
+  fontSize: "17px",
+  fontWeight: 600,
+  marginTop: 0,
+  marginBottom: "8px",
+};
+
+const taskMessageStyle: React.CSSProperties = {
+  color: "#404040",
+  fontSize: "14px",
+  lineHeight: "22px",
+  margin: 0,
+  whiteSpace: "pre-wrap",
+};
+
+const hrStyle: React.CSSProperties = {
+  borderColor: "#e6ebf1",
+  margin: "24px 0",
+};
+
+const footerStyle: React.CSSProperties = {
+  color: "#8898aa",
+  fontSize: "13px",
+  marginBottom: 0,
+};

--- a/supabase/functions/send-pending-emails/index.ts
+++ b/supabase/functions/send-pending-emails/index.ts
@@ -1,0 +1,40 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { Resend } from "npm:resend";
+
+Deno.serve(async () => {
+  const supabase = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
+  const resend = new Resend(Deno.env.get("RESEND_API_KEY")!);
+
+  // Pull up to 100 pending (task, assignee) email jobs
+  const { data: jobs, error } = await supabase.rpc("get_pending_email_jobs", {
+    p_limit: 100,
+  });
+  if (error) throw error;
+  if (!jobs?.length) return new Response("no pending emails");
+
+  // Build the Resend batch payload
+  const batch = jobs.map((j) => ({
+    from: "reminders@yourdomain.com",
+    to: j.member_email,
+    subject: `Task: ${j.task_title}`,
+    html: renderEmail(j), // your template
+  }));
+
+  const result = await resend.batch.send(batch);
+
+  // Mark the touched tasks as sent. Note: a task may appear in `jobs`
+  // multiple times (group task with N assignees → N rows), but we only
+  // need to mark email_sent_at once per task. Use a Set to dedupe.
+  const taskIds = [...new Set(jobs.map((j) => j.task_id))];
+
+  if (result.error) {
+    await supabase.rpc("increment_email_attempts", {
+      p_task_ids: taskIds,
+      p_error: result.error.message,
+    });
+  } else {
+    await supabase.from("tasks").update({ email_sent_at: new Date().toISOString() }).in("id", taskIds);
+  }
+
+  return new Response(JSON.stringify({ sent: batch.length }));
+});

--- a/supabase/functions/send-pending-emails/index.ts
+++ b/supabase/functions/send-pending-emails/index.ts
@@ -1,5 +1,8 @@
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { Resend } from "npm:resend";
+import { render } from "npm:@react-email/render@1.0.4";
+import * as React from "npm:react@19.0.0";
+import { TaskEmail } from "../_shared/emails/TaskEmail.tsx";
 
 Deno.serve(async () => {
   const supabase = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
@@ -13,12 +16,21 @@ Deno.serve(async () => {
   if (!jobs?.length) return new Response("no pending emails");
 
   // Build the Resend batch payload
-  const batch = jobs.map((j) => ({
-    from: "reminders@yourdomain.com",
-    to: j.member_email,
-    subject: `Task: ${j.task_title}`,
-    html: renderEmail(j), // your template
-  }));
+  const batch = await Promise.all(
+    jobs.map(async (j) => ({
+      // TODO: replace "from" line with ECOSLO's email once we get their domain
+      from: "onboarding@resend.dev",
+      to: j.member_email,
+      subject: `Task: ${j.task_title}`,
+      html: await render(
+        React.createElement(TaskEmail, {
+          firstname: j.member_firstname,
+          title: j.task_title,
+          message: j.task_message,
+        }),
+      ),
+    })),
+  );
 
   const result = await resend.batch.send(batch);
 

--- a/supabase/functions/tick-reminders/index.ts
+++ b/supabase/functions/tick-reminders/index.ts
@@ -1,5 +1,5 @@
 import { createClient } from "jsr:@supabase/supabase-js@2";
-import { computeNextRunAt } from "../_shared/cron.js";
+import { getNextCronOccurrence } from "../_shared/cron.ts";
 
 Deno.serve(async () => {
   const supabase = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
@@ -19,7 +19,7 @@ Deno.serve(async () => {
   let failed = 0;
   for (const r of due ?? []) {
     try {
-      const nextRunAt = computeNextRunAt(r.crons_expression); // PST-aware
+      const nextRunAt = getNextCronOccurrence(r.crons_expression); // PST-aware
       const { error: rpcError } = await supabase.rpc("fire_reminder", {
         p_reminder_id: r.id,
         p_next_run_at: nextRunAt.toISOString(),

--- a/supabase/functions/tick-reminders/index.ts
+++ b/supabase/functions/tick-reminders/index.ts
@@ -1,0 +1,39 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { computeNextRunAt } from "../_shared/cron.js";
+
+Deno.serve(async () => {
+  const supabase = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
+
+  // Find all due reminders. No locking here — fire_reminder locks per row.
+  // LIMIT 500 is a soft cap; anything beyond it picks up next minute.
+  const { data: due, error } = await supabase
+    .from("reminders")
+    .select("id, crons_expression")
+    .eq("is_active", true)
+    .lte("next_run_at", new Date().toISOString())
+    .limit(500);
+
+  if (error) throw error;
+
+  let fired = 0;
+  let failed = 0;
+  for (const r of due ?? []) {
+    try {
+      const nextRunAt = computeNextRunAt(r.crons_expression); // PST-aware
+      const { error: rpcError } = await supabase.rpc("fire_reminder", {
+        p_reminder_id: r.id,
+        p_next_run_at: nextRunAt.toISOString(),
+      });
+      if (rpcError) throw rpcError;
+      fired++;
+    } catch (e) {
+      // Log and continue — one bad reminder shouldn't stop the others
+      console.error(`fire_reminder failed for ${r.id}:`, e);
+      failed++;
+    }
+  }
+
+  return new Response(JSON.stringify({ fired, failed, total: due?.length ?? 0 }), {
+    headers: { "content-type": "application/json" },
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase/functions"]
 }


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

Implements the automated reminder system. The general flow follows 2 cron jobs that run every minute. One job will fetch `reminders` that are ready to be triggered (using a new `next_run_at` timestamp field) and create tasks out of those reminders. It then updates the reminder's timestamp tracking fields (explained below). A different job will fetch tasks from the table that are not complete and have not had an email sent yet. It will then send an email to the associated `member` using Resend.

This involved many phases:
1. Updated the table schemas to support the automated deliveries
2. Built a Supabase RPC (Remote Procedure Call) for creating tasks whenever a reminder triggers
3. Built an RPC for sending emails when new tasks are created
4. Created a Supabase Edge Function `tick-reminder` to process due reminders
5. Created an Edge Function `send-pending-emails` to send pending emails for newly created tasks
6. Registered Supabase Cron jobs

#### 1. Update table schemas

Added the following columns to the `reminders` table:
- `next_run_at`: timestampz
- `last_run_at`: timestampz

These help us actually carry out the automated reminders. `next_run_at` tells the per-minute cron job when a reminder is ready to create tasks. `last_run_at` is just for observability and debugging, which is helpful.

Added the following columns to the `tasks` table:
- `email_sent_at`: timestampz (nullable)
- `email_attempts`: integer
- `email_last_error`: text
- `reminder_id` bigint, FK to `reminders.id`

This lets us track whether we've sent an email yet, when it was sent, how many tries it took, and errors with sending the email (if present).

#### 2. RPC for creating tasks

The `tick-reminders` cron jobs will invoke this RPC `fire_reminder` whenever it finds a reminder that's ready to send. When a ready reminder is found, it will create a new task(s) using the reminder fields. Then, it update the `reminders.next_run_at` to be the current time + the crons expression, and updates the `reminders.last_run_at` to the current time.

You can find this in Supabase --> SQL Editor --> Shared --> Reminders RPC. It implements locking to guard against race conditions and concurrency issues.

#### 3. RPC for sending emails

The `send-pending-emails` cron jobs will invoke this RPC `get_pending_email_jobs` whenever it finds a task that is not marked complete and has not had an email sent yet. It will construct an email using the `supabase/functions/_shared/emails/TaskEmail.tsx` React Email component to the member specified within the task. If it succeeds, it marks the `tasks.email_sent_at` field with the current timestamp and the `tasks.email_attempts` with the number of email tries; if it fails, it will increment the `tasks.email_attempts` and add the error message to `tasks.email_last_error`; the next time the cron job runs, it will pick up this task and try sending the email again.

You can find this in Supabase --> SQL Editor --> Shared --> Email RPC. Locking is not necessary for this RPC.

#### 4. `tick-reminder` Edge Function

An Edge Function is a serverless way to execute code. The `tick-reminder` Edge Function is basically just a function definition that will fetch ready reminders and create tasks on them.

Note: the Edge Functions are written in `/supabase/functions/` which is outside of `/src/'. This is because Edge Functions run on Deno in Supabase. Supabase recommends this filepathing in their documentation. After writing a `.ts` file defining the Edge Function, you can deploy it using

```
supabase functions deploy <edge-function-name>
```

Because this Edge Function is in `/supabase/functions/tick-reminders/index.ts`, we just need to run the `supabase functions deploy tick-reminders` command in the CLI. You may need to set up the Supabase CLI first. As I have already deployed our Edge Functions, you don't need to do this step unless you want to add something else.

You can view the Edge Functions in Supabase --> Edge Functions

#### 5. `send-pending-emails` Edge Function

Similar to the previous Edge Function, except this one pulls `tasks` and sends emails if one hasn't been sent yet, and it isn't complete. Because many tasks may be ready for email delivery at a time, this uses Resend batch payloads to send up to 500 emails at a time, keep us well below our rate limits.

#### 6. Registered Cron Job

Each of the Edge Functions gets its own Cron job. For both the `tick-reminder` and `send-pending-emails` Edge Functions, this runs every minute using the crons expression `* * * *`. These cron jobs have the same name as their Edge Function counter parts.

There is an additional Cron job that runs once a week on Sundays at 3am UTC (crons `0 3 * *0`). This is called `cleanup-cron-history` and deletes all entries in the in the automatically created `cron.job_run_details` table if they are older than 30 days. This is because the table grows unbounded by default, so we should maintain a reasonable size.

You can see the Cron Jobs in Supabase --> SQL Editor --> Shared --> List Cron Jobs. You can also run the "Recent Cron Job Run Details" query.

### Testing Considerations

Verified that tasks are being created and emails are being sent. Because we still need to set up ECOSLO's email domain, emails will only be sent if the email address is exactly `smnguyen745@gmail.com` as that is the email used to set up Resend. This email is found in the `members` table.

You should be able to look at the various timestamp fields in `reminders` and `tasks` to verify that things are being created and sent.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="903" height="485" alt="image" src="https://github.com/user-attachments/assets/9c2aa261-0462-48a4-ac38-a42fe65127ab" />

<img width="2212" height="1192" alt="image" src="https://github.com/user-attachments/assets/4c335a39-7016-45be-a2ff-aedf0f89f33f" />
