### PR TITLE
[Reminders] Implements Monthly and Yearly Repeat Pickers

### DIFF
--- a/src/app/api/admin/reminders/route.ts
+++ b/src/app/api/admin/reminders/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
 export async function GET() {
   try {
     const supabase = await createServerLevelClient();
-    const { data, error } = await supabase.from("reminders").select("*").order("created_at", { ascending: true });
+    const { data, error } = await supabase.from("reminders").select("*").order("created_at", { ascending: false });
     if (error) {
       const status = postgrestErrorToHttpStatus(error);
       return NextResponse.json({ message: error.message }, { status: status });

--- a/src/components/reminders/ReminderMonthlyDayPicker.tsx
+++ b/src/components/reminders/ReminderMonthlyDayPicker.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface ReminderMonthlyDayPickerProps {
+  /** Day of month, 1-31. `null` means nothing selected yet. */
+  value: number | null;
+  onChange: (day: number) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
+
+/**
+ * Day-of-month picker for monthly cron schedules.
+ *
+ * Deliberately *not* weekday-aligned: a monthly reminder fires on the same
+ * day-of-month regardless of weekday, so showing a calendar for a specific
+ * month (with the day "1" in some weekday column) would be misleading.
+ *
+ * Days 29-31 are still selectable — pg_cron will simply skip months that
+ * don't have that day. The footnote tells the admin what to expect.
+ */
+export default function ReminderMonthlyDayPicker({
+  value,
+  onChange,
+  disabled = false,
+  className,
+}: ReminderMonthlyDayPickerProps) {
+  return (
+    <div className={cn("rounded-3xl bg-white p-4", disabled && "bg-table-header", className)}>
+      <div className="grid grid-cols-7 gap-1.5">
+        {DAYS.map((day) => {
+          const isSelected = value === day;
+
+          return (
+            <button
+              key={day}
+              type="button"
+              disabled={disabled}
+              aria-label={`Day ${day} of the month`}
+              aria-pressed={isSelected}
+              onClick={() => onChange(day)}
+              className={cn(
+                "flex h-9 w-9 items-center justify-center rounded-full font-avenir text-sm transition-colors duration-150",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1",
+                isSelected ? "bg-primary text-text-light" : "text-text-dark",
+                !disabled && isSelected && "hover:bg-primary-light",
+                !disabled && !isSelected && "hover:bg-active-pill",
+                disabled && !isSelected && "opacity-50",
+                disabled ? "cursor-default" : "cursor-pointer",
+              )}
+            >
+              {day}
+            </button>
+          );
+        })}
+      </div>
+
+      {value !== null && value >= 29 && (
+        <p className="mt-3 font-avenir text-xs text-text-muted">
+          {value === 31
+            ? "Note: months with fewer than 31 days (Feb, Apr, Jun, Sep, Nov) will be skipped."
+            : value === 30
+              ? "Note: February will be skipped — it has 28 or 29 days."
+              : "Note: February will be skipped in non-leap years."}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/reminders/ReminderView.tsx
+++ b/src/components/reminders/ReminderView.tsx
@@ -4,11 +4,18 @@ import ReminderDropdown from "./ReminderDropdown";
 import ReminderNestedMultiSelectDropdown, { type NestedMultiSelectGroup } from "./ReminderNestedMultiSelectDropdown";
 import ReminderTextInput from "./ReminderTextInput";
 import ReminderTimePicker from "./ReminderTimePicker";
+import ReminderMonthlyDayPicker from "./ReminderMonthlyDayPicker";
+import ReminderYearlyDatePicker, { type YearlyDate } from "./ReminderYearlyDatePicker";
 import { Calendar, SquarePen, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import ReminderLongTextInput from "./ReminderLongTextInput";
 import ReminderToggleArea from "./ReminderToggleArea";
-import { createWeeklyCronExpression, cronExpressionToFormValues, getNextCronOccurrence } from "@/lib/cron_utils";
+import {
+  createCronExpression,
+  cronExpressionToFormValues,
+  getCronPreset,
+  getNextCronOccurrence,
+} from "@/lib/cron_utils";
 import type { NestedMultiSelectValue } from "./ReminderNestedMultiSelectDropdown";
 
 type MemberEnum = Enums<"MemberType">;
@@ -27,6 +34,21 @@ const DEFAULT_REMINDER_DAY = "";
 const DEFAULT_REMINDER_TIME = "";
 const DEFAULT_REMINDER_MESSAGE = "";
 
+const REPEAT_OPTIONS = ["Weekly", "Monthly", "Yearly"] as const;
+type RepeatOption = (typeof REPEAT_OPTIONS)[number];
+type ReminderRepeatPreset = "weekly" | "monthly" | "yearly";
+
+const REPEAT_LABEL_TO_PRESET: Record<RepeatOption, ReminderRepeatPreset> = {
+  Weekly: "weekly",
+  Monthly: "monthly",
+  Yearly: "yearly",
+};
+const REPEAT_PRESET_TO_LABEL: Record<ReminderRepeatPreset, RepeatOption> = {
+  weekly: "Weekly",
+  monthly: "Monthly",
+  yearly: "Yearly",
+};
+
 interface ReminderViewProps {
   assigneeLabel?: string;
   members: Member[];
@@ -43,7 +65,10 @@ type ReminderViewMode = "create" | "edit" | "view";
 
 type ReminderFormState = {
   assignees: NestedMultiSelectValue;
+  repeat: ReminderRepeatPreset;
   dayOfWeek: string;
+  dayOfMonth: number | null;
+  yearlyDate: YearlyDate | null;
   isActive: boolean;
   needsSurvey: boolean;
   message: string;
@@ -83,6 +108,11 @@ export default function ReminderView({
     setForm((current) => ({ ...current, [key]: value }));
     setSubmitError("");
     setDeleteError("");
+  };
+
+  const handleRepeatChange = (label: string) => {
+    if (!isRepeatOption(label)) return;
+    updateForm("repeat", REPEAT_LABEL_TO_PRESET[label]);
   };
 
   const handleTemplateSelect = (templateName: string) => {
@@ -151,7 +181,11 @@ export default function ReminderView({
     [members],
   );
   const templateOptions = useMemo(() => templates.map((template) => template.name), [templates]);
-  const nextSendLabel = useMemo(() => getNextSendLabel(form.dayOfWeek, form.time), [form.dayOfWeek, form.time]);
+  const nextSendLabel = useMemo(
+    () => getNextSendLabel(form),
+    // Listing schedule-relevant fields keeps this stable when name/message/etc. change.
+    [form.repeat, form.dayOfWeek, form.dayOfMonth, form.yearlyDate, form.time],
+  );
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-6 overflow-auto no-scrollbar rounded-3xl border-1 border-border bg-table-row-dark px-6 py-8">
@@ -218,17 +252,17 @@ export default function ReminderView({
           </div>
         </div>
       )}
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-4">
         <span className="font-avenir text-m font-normal text-text-dark">Schedule</span>
         <div className="flex flex-row gap-4">
-          <div className="flex basis-1/2 text-text-muted">
+          <div className="flex basis-1/2 text-text-dark">
             <ReminderDropdown
               disabled={isReadOnly}
-              label="Day of Week"
-              options={[...WEEK_DAYS]}
-              placeholder="Select a day..."
-              value={form.dayOfWeek}
-              onOptionClick={(value) => updateForm("dayOfWeek", value)}
+              label="Repeats"
+              options={[...REPEAT_OPTIONS]}
+              placeholder="Select a frequency..."
+              value={REPEAT_PRESET_TO_LABEL[form.repeat]}
+              onOptionClick={handleRepeatChange}
             />
           </div>
           <div className="flex basis-1/2 text-text-muted">
@@ -241,6 +275,43 @@ export default function ReminderView({
             />
           </div>
         </div>
+
+        {form.repeat === "weekly" && (
+          <div className="flex flex-row gap-4">
+            <div className="flex basis-1/2 text-text-muted">
+              <ReminderDropdown
+                disabled={isReadOnly}
+                label="Day of Week"
+                options={[...WEEK_DAYS]}
+                placeholder="Select a day..."
+                value={form.dayOfWeek}
+                onOptionClick={(value) => updateForm("dayOfWeek", value)}
+              />
+            </div>
+          </div>
+        )}
+
+        {form.repeat === "monthly" && (
+          <div className="flex flex-col gap-1">
+            <span className="font-avenir text-m font-normal">Day of Month</span>
+            <ReminderMonthlyDayPicker
+              disabled={isReadOnly}
+              value={form.dayOfMonth}
+              onChange={(day) => updateForm("dayOfMonth", day)}
+            />
+          </div>
+        )}
+
+        {form.repeat === "yearly" && (
+          <div className="flex flex-col gap-1">
+            <span className="font-avenir text-m font-normal">Date</span>
+            <ReminderYearlyDatePicker
+              disabled={isReadOnly}
+              value={form.yearlyDate}
+              onChange={(date) => updateForm("yearlyDate", date)}
+            />
+          </div>
+        )}
       </div>
       <div className="flex h-25 shrink-0 flex-row items-center gap-3 rounded-3xl bg-table-header">
         <Calendar className="ml-4" size={20} color="#6b7456" />
@@ -298,24 +369,74 @@ export default function ReminderView({
   );
 }
 
-function getReminderSchedule(reminder?: Reminder) {
+// ---------------------------------------------------------------------------
+// Schedule helpers
+// ---------------------------------------------------------------------------
+
+function isRepeatOption(value: string): value is RepeatOption {
+  return (REPEAT_OPTIONS as readonly string[]).includes(value);
+}
+
+/**
+ * Detect which repeat preset this UI should show for an existing cron
+ * expression. The UI only offers weekly/monthly/yearly, so daily/weekdays/
+ * custom fall back to weekly. This shouldn't be reached since every
+ * reminder this form creates uses one of the three supported presets, but
+ * the fallback keeps hydration safe if a cron is hand-edited later.
+ */
+function getReminderRepeatPreset(cronExpression: string | undefined): ReminderRepeatPreset {
+  if (!cronExpression) return "weekly";
+  try {
+    const preset = getCronPreset(cronExpression);
+    if (preset === "monthly" || preset === "yearly") return preset;
+    return "weekly";
+  } catch {
+    return "weekly";
+  }
+}
+
+type ScheduleFromCron = {
+  repeat: ReminderRepeatPreset;
+  dayOfWeek: string;
+  dayOfMonth: number | null;
+  yearlyDate: YearlyDate | null;
+  time: string;
+};
+
+function emptySchedule(): ScheduleFromCron {
+  return {
+    repeat: "weekly",
+    dayOfWeek: DEFAULT_REMINDER_DAY,
+    dayOfMonth: null,
+    yearlyDate: null,
+    time: DEFAULT_REMINDER_TIME,
+  };
+}
+
+function getReminderSchedule(reminder?: Reminder): ScheduleFromCron {
   return getScheduleFromCronExpression(reminder?.crons_expression);
 }
 
-function getScheduleFromCronExpression(cronsExpression?: string) {
-  if (!cronsExpression) {
-    return { dayOfWeek: DEFAULT_REMINDER_DAY, time: DEFAULT_REMINDER_TIME };
-  }
+function getScheduleFromCronExpression(cronsExpression?: string): ScheduleFromCron {
+  if (!cronsExpression) return emptySchedule();
 
   try {
     const values = cronExpressionToFormValues(cronsExpression);
+    const preset = getReminderRepeatPreset(cronsExpression);
+    const time = `${String(values.hour).padStart(2, "0")}:${String(values.minute).padStart(2, "0")}`;
 
     return {
-      dayOfWeek: cronDayToWeekDay(values.dayOfWeek),
-      time: `${String(values.hour).padStart(2, "0")}:${String(values.minute).padStart(2, "0")}`,
+      repeat: preset,
+      // Each repeat-specific field is only filled when its preset is active.
+      // Leaving the others at their empty defaults avoids accidentally
+      // resurfacing stale data if the user toggles between presets.
+      dayOfWeek: preset === "weekly" ? cronDayToWeekDay(values.dayOfWeek) : DEFAULT_REMINDER_DAY,
+      dayOfMonth: preset === "monthly" ? values.dayOfMonth : null,
+      yearlyDate: preset === "yearly" ? { month: values.month, day: values.dayOfMonth } : null,
+      time,
     };
   } catch {
-    return { dayOfWeek: DEFAULT_REMINDER_DAY, time: DEFAULT_REMINDER_TIME };
+    return emptySchedule();
   }
 }
 
@@ -324,7 +445,10 @@ function getTemplateFormValues(template: Template, members: Member[]): Partial<R
 
   return {
     assignees: getAssigneesFromMemberIds(template.assignees, members),
+    repeat: schedule.repeat,
     dayOfWeek: schedule.dayOfWeek,
+    dayOfMonth: schedule.dayOfMonth,
+    yearlyDate: schedule.yearlyDate,
     message: template.task_message,
     time: schedule.time,
   };
@@ -336,7 +460,10 @@ function getReminderFormState(reminder: Reminder | undefined, members: Member[])
 
   return {
     assignees: getSelectedAssignees(reminder, members),
+    repeat: schedule.repeat,
     dayOfWeek: schedule.dayOfWeek,
+    dayOfMonth: schedule.dayOfMonth,
+    yearlyDate: schedule.yearlyDate,
     isActive: reminder?.is_active ?? true,
     needsSurvey: reminderWithNeedsSurvey?.needs_survey ?? false,
     message: reminder?.task_message ?? DEFAULT_REMINDER_MESSAGE,
@@ -363,20 +490,47 @@ function getSelectedAssigneeIds(assignees: NestedMultiSelectValue) {
   return Object.values(assignees).flat().map(Number).filter(Number.isInteger);
 }
 
-function getCronExpressionFromForm(form: ReminderFormState) {
-  const cronDay = weekDayToCronDay(form.dayOfWeek);
-
-  if (cronDay === null || !form.time) {
-    throw new Error("Select a day and time before saving.");
+/**
+ * Build a cron expression from the current form state, throwing a
+ * user-facing error if the schedule isn't fully specified yet.
+ */
+function getCronExpressionFromForm(form: ReminderFormState): string {
+  if (!form.time) {
+    throw new Error("Select a time before saving.");
   }
 
   const [hour, minute] = form.time.split(":").map(Number);
-
   if (!Number.isInteger(hour) || !Number.isInteger(minute)) {
     throw new Error("Select a valid time before saving.");
   }
+  const time = { hour, minute };
 
-  return createWeeklyCronExpression({ hour, minute }, cronDay);
+  switch (form.repeat) {
+    case "weekly": {
+      const cronDay = weekDayToCronDay(form.dayOfWeek);
+      if (cronDay === null) {
+        throw new Error("Select a day of the week before saving.");
+      }
+      return createCronExpression({ repeat: "weekly", time, dayOfWeek: cronDay });
+    }
+    case "monthly": {
+      if (form.dayOfMonth === null) {
+        throw new Error("Select a day of the month before saving.");
+      }
+      return createCronExpression({ repeat: "monthly", time, dayOfMonth: form.dayOfMonth });
+    }
+    case "yearly": {
+      if (!form.yearlyDate) {
+        throw new Error("Select a date before saving.");
+      }
+      return createCronExpression({
+        repeat: "yearly",
+        time,
+        dayOfMonth: form.yearlyDate.day,
+        month: form.yearlyDate.month,
+      });
+    }
+  }
 }
 
 function getReminderPayload(form: ReminderFormState): ReminderInsertPayload {
@@ -472,21 +626,34 @@ function weekDayToCronDay(dayOfWeek: string) {
   return weekDayIndex < 0 ? null : (weekDayIndex + 1) % 7;
 }
 
-function getNextSendLabel(dayOfWeek: string, time: string) {
-  const cronDay = weekDayToCronDay(dayOfWeek);
+/**
+ * Compute the human-readable "Next Send" line shown below the schedule.
+ *
+ * Mirrors getCronExpressionFromForm's validation rules but returns the
+ * shortcoming as a UI string rather than throwing. Returning early on each
+ * missing field gives the user a precise nudge ("Select a day of the
+ * month") instead of a generic "schedule incomplete".
+ */
+function getNextSendLabel(form: ReminderFormState): string {
+  if (!form.time) return "Select a time";
 
-  if (cronDay === null || !time) {
-    return "Select a day and time";
-  }
+  const [hour, minute] = form.time.split(":").map(Number);
+  if (!Number.isInteger(hour) || !Number.isInteger(minute)) return "Select a valid time";
 
-  const [hour, minute] = time.split(":").map(Number);
-
-  if (!Number.isInteger(hour) || !Number.isInteger(minute)) {
-    return "Select a valid time";
+  switch (form.repeat) {
+    case "weekly":
+      if (weekDayToCronDay(form.dayOfWeek) === null) return "Select a day of the week";
+      break;
+    case "monthly":
+      if (form.dayOfMonth === null) return "Select a day of the month";
+      break;
+    case "yearly":
+      if (!form.yearlyDate) return "Select a date";
+      break;
   }
 
   try {
-    const expression = createWeeklyCronExpression({ hour, minute }, cronDay);
+    const expression = getCronExpressionFromForm(form);
     return formatNextSendDate(getNextCronOccurrence(expression));
   } catch {
     return "Select a valid schedule";

--- a/src/components/reminders/ReminderYearlyDatePicker.tsx
+++ b/src/components/reminders/ReminderYearlyDatePicker.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+export interface YearlyDate {
+  /** 1-12 */
+  month: number;
+  /** 1-31, must be valid for the chosen month */
+  day: number;
+}
+
+interface ReminderYearlyDatePickerProps {
+  value: YearlyDate | null;
+  onChange: (value: YearlyDate) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+const WEEKDAY_LABELS = ["S", "M", "T", "W", "T", "F", "S"] as const;
+
+/**
+ * Reference year for laying out the calendar grid. 2024 is a leap year so
+ * Feb 29 is selectable; the warning footnote explains the consequence.
+ *
+ * The reference year is *not* stored anywhere. Only `month` and `day` flow
+ * out of this component; the cron for yearly schedules is `M H D Mo *` —
+ * no year component.
+ */
+const REFERENCE_YEAR = new Date().getUTCFullYear();
+
+function getDaysInMonth(month: number): number {
+  // month is 1-indexed; Date(year, month, 0) gives the last day of month-1.
+  return new Date(REFERENCE_YEAR, month, 0).getDate();
+}
+
+function getFirstWeekdayOfMonth(month: number): number {
+  return new Date(REFERENCE_YEAR, month - 1, 1).getDay();
+}
+
+/**
+ * Month-navigable date picker for yearly cron schedules. Year is hidden
+ * because the reminder repeats annually — only month + day matter.
+ */
+export default function ReminderYearlyDatePicker({
+  value,
+  onChange,
+  disabled = false,
+  className,
+}: ReminderYearlyDatePickerProps) {
+  const [viewMonth, setViewMonth] = useState<number>(value?.month ?? new Date().getMonth() + 1);
+
+  // If the parent swaps the value (e.g. switching between reminders), jump
+  // the calendar view to the new value's month.
+  const [prevValueMonth, setPrevValueMonth] = useState<number | undefined>(value?.month);
+  if (value?.month !== prevValueMonth) {
+    setPrevValueMonth(value?.month);
+    if (value?.month) setViewMonth(value.month);
+  }
+
+  const daysInMonth = getDaysInMonth(viewMonth);
+  const firstWeekday = getFirstWeekdayOfMonth(viewMonth);
+  const days = Array.from({ length: daysInMonth }, (_, i) => i + 1);
+
+  const handlePrev = () => {
+    if (disabled) return;
+    setViewMonth((m) => (m === 1 ? 12 : m - 1));
+  };
+
+  const handleNext = () => {
+    if (disabled) return;
+    setViewMonth((m) => (m === 12 ? 1 : m + 1));
+  };
+
+  const handleSelect = (day: number) => {
+    if (disabled) return;
+    onChange({ month: viewMonth, day });
+  };
+
+  const showLeapWarning = value?.month === 2 && value?.day === 29;
+
+  return (
+    <div className={cn("rounded-3xl bg-white p-4", disabled && "bg-table-header", className)}>
+      <div className="mb-3 flex items-center justify-between">
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={handlePrev}
+          aria-label="Previous month"
+          className={cn(
+            "flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-150",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1",
+            disabled ? "cursor-default opacity-50" : "cursor-pointer hover:bg-active-pill",
+          )}
+        >
+          <ChevronLeft className="h-4 w-4 text-text-dark" />
+        </button>
+
+        <span className="font-avenir text-m font-medium text-text-dark">{MONTH_NAMES[viewMonth - 1]}</span>
+
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={handleNext}
+          aria-label="Next month"
+          className={cn(
+            "flex h-8 w-8 items-center justify-center rounded-full transition-colors duration-150",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1",
+            disabled ? "cursor-default opacity-50" : "cursor-pointer hover:bg-active-pill",
+          )}
+        >
+          <ChevronRight className="h-4 w-4 text-text-dark" />
+        </button>
+      </div>
+
+      <div className="mb-1 grid grid-cols-7 gap-1.5">
+        {WEEKDAY_LABELS.map((label, idx) => (
+          <span
+            key={`${label}-${idx}`}
+            className="flex h-6 items-center justify-center font-avenir text-xs text-text-muted"
+          >
+            {label}
+          </span>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7 gap-1.5">
+        {/* Empty cells before the 1st */}
+        {Array.from({ length: firstWeekday }).map((_, i) => (
+          <div key={`pad-${i}`} className="h-9 w-9" aria-hidden="true" />
+        ))}
+
+        {days.map((day) => {
+          const isSelected = value?.month === viewMonth && value?.day === day;
+
+          return (
+            <button
+              key={day}
+              type="button"
+              disabled={disabled}
+              aria-label={`${MONTH_NAMES[viewMonth - 1]} ${day}`}
+              aria-pressed={isSelected}
+              onClick={() => handleSelect(day)}
+              className={cn(
+                "flex h-9 w-9 items-center justify-center rounded-full font-avenir text-sm transition-colors duration-150",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1",
+                isSelected ? "bg-primary text-text-light" : "text-text-dark",
+                !disabled && isSelected && "hover:bg-primary-light",
+                !disabled && !isSelected && "hover:bg-active-pill",
+                disabled && !isSelected && "opacity-50",
+                disabled ? "cursor-default" : "cursor-pointer",
+              )}
+            >
+              {day}
+            </button>
+          );
+        })}
+      </div>
+
+      {showLeapWarning && (
+        <p className="mt-3 font-avenir text-xs text-text-muted">
+          Note: February 29 only exists in leap years — this reminder will fire once every four years.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/cron_utils.ts
+++ b/src/lib/cron_utils.ts
@@ -347,18 +347,12 @@ function matchesCronField(field: CronFieldName, token: string, value: number): b
   return !!allowedValues?.includes(value);
 }
 
-function matchesCronDate(parts: CronParts, date: Date): boolean {
-  // Read all wall-clock fields once in Pacific time. Using
-  // getPacificFields here is what makes cron evaluation timezone-correct
-  // when this runs on a non-Pacific host (Vercel/UTC, Supabase/UTC).
-  const fields = getPacificFields(date);
-
-  const minuteMatches = matchesCronField("minute", parts.minute, fields.minute);
-  const hourMatches = matchesCronField("hour", parts.hour, fields.hour);
-  const monthMatches = matchesCronField("month", parts.month, fields.month);
-
-  if (!minuteMatches || !hourMatches || !monthMatches) return false;
-
+/**
+ * Standard cron day-field semantics: if BOTH dayOfMonth and dayOfWeek are
+ * restricted (non-wildcard), a date matches when EITHER matches; otherwise
+ * the restricted field (or both wildcards) must match.
+ */
+function matchesCronDayFields(parts: CronParts, fields: PacificFields): boolean {
   const dayOfMonthMatches = matchesCronField("dayOfMonth", parts.dayOfMonth, fields.dayOfMonth);
   const dayOfWeekMatches = matchesCronField("dayOfWeek", parts.dayOfWeek, fields.dayOfWeek);
   const restrictsDayOfMonth = !isWildcard(parts.dayOfMonth);
@@ -478,20 +472,50 @@ export function getNextCronOccurrence(expression: string, fromDate: Date = new D
   const parts = parseCronExpression(expression);
 
   // Floor to the start of the current UTC minute, then advance by one minute.
-  // Pure timestamp arithmetic only — we deliberately avoid Date methods like
-  // setSeconds/setMinutes here. Those operate on LOCAL fields, which has two
-  // problems: (a) on a UTC host, "local" means UTC and cron fields would not
-  // be interpreted in Pacific; (b) on a Pacific host, ambiguous local times
-  // during the fall-back hour cause setSeconds to silently shift the
-  // underlying timestamp by an hour.
+  // Pure timestamp arithmetic only — same DST-safety reasoning as before:
+  // touching local fields via setSeconds/setMinutes is unsafe during the
+  // fall-back ambiguous hour.
   let timestampMs = Math.floor(fromDate.getTime() / 60_000) * 60_000 + 60_000;
   const next = new Date(timestampMs);
 
+  // Upper bound expressed in minutes of look-ahead. Each loop iteration
+  // advances by at least one minute (either a single-minute step inside a
+  // matching hour, or a multi-minute jump to the next UTC hour boundary),
+  // so this still bounds the total search to ~5 years of clock time even
+  // though most iterations now cover much more than one minute.
   const MAX_MINUTE_LOOKAHEAD = 60 * 24 * 366 * 5;
 
   for (let i = 0; i < MAX_MINUTE_LOOKAHEAD; i += 1) {
-    if (matchesCronDate(parts, next)) return new Date(next);
-    timestampMs += 60_000;
+    const fields = getPacificFields(next);
+
+    // Short-circuit from cheapest to most expensive: month gates everything
+    // else; day-of-month/day-of-week is the next gate; hour gates the
+    // per-minute walk. The `matchesCronField` calls themselves are cheap
+    // compared to `getPacificFields` (which we've already paid for above),
+    // so the savings come from avoiding the minute-level walk, not from
+    // skipping the field checks.
+    const monthMatches = matchesCronField("month", parts.month, fields.month);
+    const dayMatches = monthMatches && matchesCronDayFields(parts, fields);
+    const hourMatches = dayMatches && matchesCronField("hour", parts.hour, fields.hour);
+
+    if (hourMatches) {
+      if (matchesCronField("minute", parts.minute, fields.minute)) {
+        return new Date(next);
+      }
+      // Inside a matching month/day/hour but wrong minute — walk one minute.
+      // We can't skip here: the right minute might be in this same hour.
+      timestampMs += 60_000;
+      next.setTime(timestampMs);
+      continue;
+    }
+
+    // Month, day, or hour doesn't match. Jump to the next UTC hour boundary
+    // (minute=00). This guarantees we never overshoot the cron's minute
+    // target on the next hour-match: we always re-enter the minute-walk
+    // with a clean minute=00 starting point.
+    const minutesIntoUtcHour = next.getUTCMinutes();
+    const minutesToNextHour = 60 - minutesIntoUtcHour;
+    timestampMs += minutesToNextHour * 60_000;
     next.setTime(timestampMs);
   }
 

--- a/supabase/functions/_shared/cron.ts
+++ b/supabase/functions/_shared/cron.ts
@@ -209,27 +209,6 @@ function matchesCronField(field: CronFieldName, token: string, value: number): b
   return !!allowedValues?.includes(value);
 }
 
-function matchesCronDate(parts: CronParts, date: Date): boolean {
-  const fields = getPacificFields(date);
-
-  if (!matchesCronField("minute", parts.minute, fields.minute)) return false;
-  if (!matchesCronField("hour", parts.hour, fields.hour)) return false;
-  if (!matchesCronField("month", parts.month, fields.month)) return false;
-
-  const dayOfMonthMatches = matchesCronField("dayOfMonth", parts.dayOfMonth, fields.dayOfMonth);
-  const dayOfWeekMatches = matchesCronField("dayOfWeek", parts.dayOfWeek, fields.dayOfWeek);
-  const restrictsDayOfMonth = parts.dayOfMonth !== "*";
-  const restrictsDayOfWeek = parts.dayOfWeek !== "*";
-
-  // Cron convention: if both day-of-month and day-of-week are restricted,
-  // a date matches if EITHER is satisfied (logical OR).
-  if (restrictsDayOfMonth && restrictsDayOfWeek) {
-    return dayOfMonthMatches || dayOfWeekMatches;
-  }
-
-  return dayOfMonthMatches && dayOfWeekMatches;
-}
-
 /** Validates whether a string is a supported 5-field cron expression. */
 export function isValidFiveFieldCronExpression(expression: string): boolean {
   const values = normalizeCronExpression(expression).split(" ");
@@ -267,20 +246,74 @@ export function getNextCronOccurrence(expression: string, fromDate: Date = new D
   const parts = parseCronExpression(expression);
 
   // Floor to the start of the current UTC minute, then advance by one minute.
-  // Pure timestamp arithmetic only — we deliberately avoid Date methods like
-  // setSeconds/setMinutes here. Those operate on LOCAL fields, which causes
-  // ambiguous-time bugs during the fall-back hour in Pacific runtime, and
-  // wrong-timezone interpretation in UTC runtime.
+  // Pure timestamp arithmetic only — same DST-safety reasoning as before:
+  // touching local fields via setSeconds/setMinutes is unsafe during the
+  // fall-back ambiguous hour.
   let timestampMs = Math.floor(fromDate.getTime() / 60_000) * 60_000 + 60_000;
   const next = new Date(timestampMs);
 
+  // Upper bound expressed in minutes of look-ahead. Each loop iteration
+  // advances by at least one minute (either a single-minute step inside a
+  // matching hour, or a multi-minute jump to the next UTC hour boundary),
+  // so this still bounds the total search to ~5 years of clock time even
+  // though most iterations now cover much more than one minute.
   const MAX_MINUTE_LOOKAHEAD = 60 * 24 * 366 * 5;
 
   for (let i = 0; i < MAX_MINUTE_LOOKAHEAD; i += 1) {
-    if (matchesCronDate(parts, next)) return new Date(next);
-    timestampMs += 60_000;
+    const fields = getPacificFields(next);
+
+    // Short-circuit from cheapest to most expensive: month gates everything
+    // else; day-of-month/day-of-week is the next gate; hour gates the
+    // per-minute walk. The `matchesCronField` calls themselves are cheap
+    // compared to `getPacificFields` (which we've already paid for above),
+    // so the savings come from avoiding the minute-level walk, not from
+    // skipping the field checks.
+    const monthMatches = matchesCronField("month", parts.month, fields.month);
+    const dayMatches = monthMatches && matchesCronDayFields(parts, fields);
+    const hourMatches = dayMatches && matchesCronField("hour", parts.hour, fields.hour);
+
+    if (hourMatches) {
+      if (matchesCronField("minute", parts.minute, fields.minute)) {
+        return new Date(next);
+      }
+      // Inside a matching month/day/hour but wrong minute — walk one minute.
+      // We can't skip here: the right minute might be in this same hour.
+      timestampMs += 60_000;
+      next.setTime(timestampMs);
+      continue;
+    }
+
+    // Month, day, or hour doesn't match. Jump to the next UTC hour boundary
+    // (minute=00). This guarantees we never overshoot the cron's minute
+    // target on the next hour-match: we always re-enter the minute-walk
+    // with a clean minute=00 starting point.
+    const minutesIntoUtcHour = next.getUTCMinutes();
+    const minutesToNextHour = 60 - minutesIntoUtcHour;
+    timestampMs += minutesToNextHour * 60_000;
     next.setTime(timestampMs);
   }
 
   throw new Error(`Could not find next occurrence for cron expression within 5 years: "${expression}"`);
+}
+
+/**
+ * Standard cron day-field semantics: if BOTH dayOfMonth and dayOfWeek are
+ * restricted (non-wildcard), a date matches when EITHER matches; otherwise
+ * the restricted field (or both wildcards) must match.
+ */
+function matchesCronDayFields(parts: CronParts, fields: PacificFields): boolean {
+  const dayOfMonthMatches = matchesCronField("dayOfMonth", parts.dayOfMonth, fields.dayOfMonth);
+  const dayOfWeekMatches = matchesCronField("dayOfWeek", parts.dayOfWeek, fields.dayOfWeek);
+  const restrictsDayOfMonth = !isWildcard(parts.dayOfMonth);
+  const restrictsDayOfWeek = !isWildcard(parts.dayOfWeek);
+
+  if (restrictsDayOfMonth && restrictsDayOfWeek) {
+    return dayOfMonthMatches || dayOfWeekMatches;
+  }
+
+  return dayOfMonthMatches && dayOfWeekMatches;
+}
+
+function isWildcard(value: string): boolean {
+  return value === "*";
 }


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

Implements reminder repeat picking with a monthly and yearly frequency. Two new components are created to represent each type of repeat pattern:
- `src/components/reminders/ReminderMonthlyDayPicker.tsx.`
- `src/components/reminders/ReminderYearlyDatePicker.tsx`

The `RemindersView.tsx` component is updated to incorporate both of these.

After repeat selection, the `RemindersView` will display the next scheduled run. Upon creation, it will store this next scheduled run in `reminders.next_run_at`, which the `tick-reminders` cron job will run against. Editing a reminder will also edit its `next_run_at` field. All timestamps are calculated using `America/Los Angeles` UTC time. Note: Supabase, by default, will store the timestamps in UTC (PST is UTC-8). You can see both timestamps by clicking on it and hovering over the time.

Updates the `src/lib/cron_utils.ts` and `supabase/functions/_shared/cron.ts` utility files with better optimized cron operations when finding the next cron occurrence.

#### Backlog Items

A couple of backlog items to fix down the line. They're mostly styling, so I'll ship this anyways and return to these later:
- Center dates with days of the week in the yearly picker
- Unify next send display: the "next send at" display on the Reminders list on the left side uses 24-hr format, but on the view card (right side), it uses AM/PM format. These should be consistent.

### Testing Considerations

We can now create Reminders using weekly, monthly, and yearly frequency. Went through add, edit, and delete flow and verified outputs in Supabase.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

**Monthly Picker**

<img width="881" height="484" alt="image" src="https://github.com/user-attachments/assets/eb11fd12-0242-4e04-931e-89ca22c3a22c" />


**Yearly Picker**

<img width="856" height="509" alt="image" src="https://github.com/user-attachments/assets/2918e461-7a73-42c5-8ac0-7c0a84fe0d87" />

