### PR TITLE
Improves Route Redirects

### DIFF
--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -2,6 +2,7 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
 export async function updateSession(request: NextRequest) {
+  const ADMIN_ONLY_PATHS: [string] = ["/reminders"];
   let supabaseResponse = NextResponse.next({
     request,
   });
@@ -24,12 +25,42 @@ export async function updateSession(request: NextRequest) {
   } = await supabase.auth.getUser();
 
   const isPublicRoute = request.nextUrl.pathname.startsWith("/login") || request.nextUrl.pathname.startsWith("/auth");
+  const pathname = request.nextUrl.pathname;
 
-  if (!user && !isPublicRoute) {
-    const loginUrl = request.nextUrl.clone();
-    loginUrl.pathname = "/login";
-    loginUrl.search = "";
-    return NextResponse.redirect(loginUrl);
+  const redirectTo = (path: string) => {
+    const url = request.nextUrl.clone();
+    url.pathname = path;
+    url.search = "";
+    const response = NextResponse.redirect(url);
+    supabaseResponse.cookies.getAll().forEach((cookie) => {
+      response.cookies.set(cookie);
+    });
+    return response;
+  };
+
+  // 1) Landing: "/" is never served — route by auth state.
+  if (pathname === "/") {
+    return redirectTo(user ? "/dashboard" : "/map");
+  }
+
+  // 2) Any other matched path requires authentication.
+  if (!user) {
+    return redirectTo("/login");
+  }
+
+  // 3) Admin-only paths: gate by members.role
+  const requiresAdmin = ADMIN_ONLY_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+  if (requiresAdmin) {
+    const { data: isAdmin, error } = await supabase.rpc("is_admin");
+
+    if (error) {
+      // Fail closed: if we can't verify admin status, send to /dashboard
+      console.error("[middleware] members role lookup failed:", error);
+      return redirectTo("/dashboard");
+    }
+    if (!isAdmin) {
+      return redirectTo("/dashboard");
+    }
   }
 
   return supabaseResponse;

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -2,7 +2,7 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
 export async function updateSession(request: NextRequest) {
-  const ADMIN_ONLY_PATHS: [string] = ["/reminders"];
+  const ADMIN_ONLY_PATHS: [string] = ["/reminders", "/members"];
   let supabaseResponse = NextResponse.next({
     request,
   });

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -2,7 +2,7 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
 export async function updateSession(request: NextRequest) {
-  const ADMIN_ONLY_PATHS: [string] = ["/reminders", "/members"];
+  const ADMIN_ONLY_PATHS: string[] = ["/reminders", "/members"];
   let supabaseResponse = NextResponse.next({
     request,
   });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,12 +11,13 @@ export const config = {
      * Feel free to modify this pattern to include more paths.
      */
     // "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
-    "/dashboard",
-    "/trees",
-    "/members",
-    "/reminders",
-    "/tasks",
-    "/surveys",
+    "/dashboard/:path*",
+    "/trees/:path*",
+    "/members/:path*",
+    "/reminders/:path*",
+    "/tasks/:path*",
+    "/surveys/:path*",
+    "/",
   ],
 };
 


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

Updates the proxy and middleware to handle route redirection based on the user's authentication. We now have the following redirects:
- `/`: the landing page will redirect anon (unauthenticated) users to the `/map` page; authenticated users go to the `/dashobard` page
- `/*`: anon users attempting to access any route besides `/`, `/map`, and `/login` will get re-routed to the `/login` page
- `/reminders` and `/members`: tree keepers (authenticated) will get redirected to the `/dashboard` page if they try accessing an admin-only page. Currently, only reminders and members are classified as admin-only

### Testing Considerations

N/A

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

N/A
