### PR TITLE
feat: trees page functionality, CSV feature cleanup and fixes, map page cleanup and fixes

### DIFF
--- a/src/app/(admin)/members/page.tsx
+++ b/src/app/(admin)/members/page.tsx
@@ -2,19 +2,20 @@
 
 import { MemberSchema } from "@/components/data-table/table-widget-defs";
 import MemberPageTableWidget from "@/components/MemberPageTableWidget";
-import { Plus } from "lucide-react";
+import { Download, Plus } from "lucide-react";
 import { useRef, useState } from "react";
 import { Table } from "@/components/data-table/table/table-types";
 import MembersControlPanel from "@/components/MembersControlPanel";
 import VolunteerPageForm from "@/components/volunteer-page-form";
 import { AppButton } from "@/components/ui/form-controls";
 import { AdminPageShell } from "@/components/admin-page-shell";
+import { downloadMemberCSV, dataToCSV } from "./utils/csv";
 
 export default function Volunteers() {
   const tableRef = useRef<Table<MemberSchema> | null>(null);
+  const refetchRef = useRef<(() => void) | null>(null);
   const [memberModalOpen, setMemberModalOpen] = useState(false);
   const [modalMember, setModalMember] = useState<MemberSchema | null>(null);
-  const [tableRefreshKey, setTableRefreshKey] = useState(0);
 
   const handleAddVolunteerClick = () => {
     setModalMember(null);
@@ -30,15 +31,38 @@ export default function Volunteers() {
     <AdminPageShell
       title="Members"
       actions={
-        <AppButton icon={Plus} onClick={handleAddVolunteerClick} type="button">
-          Add Member
-        </AppButton>
+        <>
+          <AppButton
+            variant="secondary"
+            size="md"
+            radius="small"
+            icon={Download}
+            onClick={() => {
+              downloadMemberCSV(
+                dataToCSV(
+                  tableRef?.current?.getRowModels().map((rowModel) => {
+                    const row: Record<string, unknown> = {};
+                    rowModel.cells.forEach((cell) => {
+                      row[cell.column.id] = cell.value;
+                    });
+                    return row;
+                  }) ?? [],
+                ),
+              );
+            }}
+          >
+            Export CSV
+          </AppButton>
+          <AppButton radius="small" icon={Plus} onClick={handleAddVolunteerClick} type="button">
+            Add Member
+          </AppButton>
+        </>
       }
     >
       <MembersControlPanel tableRef={tableRef} />
 
       <MemberPageTableWidget
-        key={tableRefreshKey}
+        refetchRef={refetchRef}
         onRowClick={(e, member) => {
           e.stopPropagation();
           setModalMember(member);
@@ -52,7 +76,7 @@ export default function Volunteers() {
       <VolunteerPageForm
         member={modalMember}
         onOpenChange={handleModalOpenChange}
-        onSaved={() => setTableRefreshKey((currentKey) => currentKey + 1)}
+        onSaved={() => refetchRef.current?.()}
         open={memberModalOpen}
       />
     </AdminPageShell>

--- a/src/app/(admin)/members/utils/csv.ts
+++ b/src/app/(admin)/members/utils/csv.ts
@@ -1,0 +1,22 @@
+import { dataToCSV } from "../../trees/utils/csv";
+
+function localeISOString(date: Date): string {
+  const tzOffset = date.getTimezoneOffset() * 60000;
+  const localISOTime = new Date(date.getTime() - tzOffset).toISOString().slice(0, -5);
+  return localISOTime;
+}
+
+export function downloadMemberCSV(csv: string) {
+  const date = localeISOString(new Date());
+  const blob = new Blob([csv], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `members_export_${date}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export { dataToCSV };

--- a/src/app/(admin)/trees/page.tsx
+++ b/src/app/(admin)/trees/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 import TreePageTableWidget from "@/components/TreePageTableWidget";
 import ControlPanel from "@/components/ControlPanel";
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { TreeSchema } from "@/components/data-table/table-widget-defs";
-import TreeDetailsPopout from "@/components/TreeDetailsPopout";
-import { useRef } from "react";
+import TreeDetailModal from "@/components/tree-detail-modal";
 import { Table } from "@/components/data-table/table/table-types";
 import { Download, Plus } from "lucide-react";
 import { downloadTreeCSV, dataToCSV } from "./utils/csv";
@@ -12,23 +11,30 @@ import { AppButton } from "@/components/ui/form-controls";
 import { AdminPageShell } from "@/components/admin-page-shell";
 
 export default function Trees() {
-  const [currentTree, setCurrentTree] = useState<TreeSchema | null>(null);
   const tableRef = useRef<Table<TreeSchema> | null>(null);
+  const refetchRef = useRef<(() => void) | null>(null);
+  const [treeModalOpen, setTreeModalOpen] = useState(false);
+  const [modalTree, setModalTree] = useState<TreeSchema | null>(null);
+  const [tableVersion, setTableVersion] = useState(0);
+
+  const handleTableReady = useCallback((table: Table<TreeSchema>) => {
+    tableRef.current = table;
+    setTableVersion((v) => v + 1);
+  }, []);
+
+  const handleAddTreeClick = () => {
+    setModalTree(null);
+    setTreeModalOpen(true);
+  };
+
+  const handleModalOpenChange = (open: boolean) => {
+    setTreeModalOpen(open);
+    if (!open) setModalTree(null);
+  };
 
   return (
     <AdminPageShell
       title="Trees"
-      onClick={() => setCurrentTree(null)}
-      beforeContent={
-        <div className="fixed top-3 -right-100 h-auto w-auto z-30 ">
-          <TreeDetailsPopout
-            key={currentTree != null ? String(currentTree.id) : "closed"}
-            admin={true}
-            tree={currentTree != null ? currentTree : undefined}
-            onClose={() => setCurrentTree(null)}
-          />
-        </div>
-      }
       actions={
         <>
           <AppButton
@@ -52,24 +58,28 @@ export default function Trees() {
           >
             Export CSV
           </AppButton>
-          <AppButton radius="small" icon={Plus}>
+          <AppButton radius="small" icon={Plus} onClick={handleAddTreeClick}>
             Add Tree
           </AppButton>
         </>
       }
     >
-      {/* control panel placeholder */}
-      <ControlPanel tableRef={tableRef} />
-      {/* trees table placeholder */}
+      <ControlPanel tableRef={tableRef} tableVersion={tableVersion} />
       <TreePageTableWidget
+        refetchRef={refetchRef}
         onRowClick={(event, tree) => {
           event.stopPropagation();
-          setCurrentTree(tree);
+          setModalTree(tree);
+          setTreeModalOpen(true);
         }}
-        onTableReady={(table) => {
-          tableRef.current = table;
-        }}
+        onTableReady={handleTableReady}
         className="w-full max-w-full"
+      />
+      <TreeDetailModal
+        tree={modalTree}
+        open={treeModalOpen}
+        onOpenChange={handleModalOpenChange}
+        onSaved={() => refetchRef.current?.()}
       />
     </AdminPageShell>
   );

--- a/src/app/(admin)/trees/utils/csv.ts
+++ b/src/app/(admin)/trees/utils/csv.ts
@@ -1,60 +1,29 @@
-import { Database } from "../../../../database/database.types";
-import { TreeSchema } from "@/components/data-table/table-widget-defs";
+function csvEscapeValue(value: unknown): string {
+  if (value == null) return "";
+  const str = Array.isArray(value) ? value.join(", ") : String(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
 
-type Tree = Database["public"]["Tables"]["trees"]["Row"];
-
-/**
- * Converts an array of objects to a CSV string.
- * @param data The array of objects to convert
- * @param headers Optional array of header strings. If not provided, object keys will be used as headers.
- *                Headers must be valid object keys.
- * @returns The CSV string representation of the data
- */
 export function dataToCSV(data: Record<string, unknown>[], headers?: string[]): string {
   if (data.length === 0) return headers ? headers.join(",") : "";
   const keys = headers || Object.keys(data[0]);
-  const csvRows = data.map((val) => keys.map((key) => JSON.stringify(val[key] ?? "")).join(","));
+  const csvRows = data.map((val) => keys.map((key) => csvEscapeValue(val[key])).join(","));
   return [keys.join(","), ...csvRows].join("\n");
 }
 
-/**
- * Converts an array of Tree objects to a CSV string.
- * @param trees The array of Tree objects to convert to CSV
- * @returns The CSV string representation of the tree data
- */
-function treesToCSV(trees: Tree[]): string {
-  return dataToCSV(trees);
-}
-
 function localeISOString(date: Date): string {
-  const tzOffset = date.getTimezoneOffset() * 60000; // offset in milliseconds
-  const localISOTime = new Date(date.getTime() - tzOffset).toISOString().slice(0, -5); // chop off ms
+  const tzOffset = date.getTimezoneOffset() * 60000;
+  const localISOTime = new Date(date.getTime() - tzOffset).toISOString().slice(0, -5);
   return localISOTime;
 }
 
-/**
- * Downloads CSV file containing all tree data
- */
-export async function fetchAndDownloadTreeCSV() {
-  const response = await fetch("/api/public/trees");
-  if (!response.ok) {
-    console.error("Failed to fetch tree data for CSV export: ", response.statusText);
-    return;
-  }
-  const trees: Tree[] = (await response.json()).message as Tree[];
-
-  downloadTreeCSV(treesToCSV(trees));
-}
-
-export async function treeSchemaToDownloadCSV(trees: TreeSchema[]) {
-  downloadTreeCSV(dataToCSV(trees));
-}
-
-export async function downloadTreeCSV(csv: string) {
+export function downloadTreeCSV(csv: string) {
   const date = localeISOString(new Date());
   const blob = new Blob([csv], { type: "text/csv" });
   const url = URL.createObjectURL(blob);
-  // Create temporary link to trigger download
   const a = document.createElement("a");
   a.href = url;
   a.download = `trees_export_${date}.csv`;

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -115,7 +115,7 @@ export default function LoginPage() {
       <LoginShell>
         <LoginCard>
           <h1 className="mb-5 text-center font-serif text-[24px] font-normal leading-tight text-text">{LOGIN_TITLE}</h1>
-          <label htmlFor="login-email" className="mb-2 block font-mulish text-[12px] font-bold text-text">
+          <label htmlFor="login-email" className="mb-2 block font-mulish text-[12px] font-bold text-text-muted">
             {EMAIL_LABEL}
           </label>
           <TextField
@@ -136,17 +136,19 @@ export default function LoginPage() {
           >
             {isSubmitting ? "Sending..." : CONFIRM_BUTTON_TEXT}
           </AppButton>
-          <AppButton
-            type="button"
-            className="mx-auto mt-4"
-            size="sm"
-            variant="ghost"
-            onClick={() => {
-              window.location.href = "/map";
-            }}
-          >
-            Back to Public Map
-          </AppButton>
+          <div className="w-full flex flex-row justify-center">
+            <AppButton
+              type="button"
+              className="mt-4"
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                window.location.href = "/map";
+              }}
+            >
+              Back to Public Map
+            </AppButton>
+          </div>
         </LoginCard>
       </LoginShell>
     );

--- a/src/app/api/admin/members/[id]/route.ts
+++ b/src/app/api/admin/members/[id]/route.ts
@@ -1,7 +1,7 @@
 import { createServerLevelClient, createServiceRoleClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 import { postgrestErrorToHttpStatus } from "@/database/utils";
-import { updateMemberEmail } from "@/lib/admin/members";
+import { syncTreeAssignments, updateMemberEmail } from "@/lib/admin/members";
 
 type IParams = {
   params: Promise<{
@@ -91,11 +91,31 @@ export async function PUT(request: NextRequest, { params }: IParams) {
       }
     }
 
-    // Non-email fields: use the user-level client so RLS still validates
-    // the caller is an admin. (The is_admin check above is redundant with
-    // RLS but provides a cleaner 403 instead of "0 rows updated.")
+    const adminClient = await createServiceRoleClient();
+
+    // If trees_assigned changed, sync tree_keeper_id on affected trees.
+    if (rest.trees_assigned !== undefined) {
+      const { data: oldMember } = await adminClient
+        .from("members")
+        .select("trees_assigned")
+        .eq("id", memberId)
+        .single();
+
+      const oldTrees: number[] = Array.isArray(oldMember?.trees_assigned)
+        ? oldMember.trees_assigned.filter((n: unknown): n is number => typeof n === "number")
+        : [];
+      const newTrees: number[] = Array.isArray(rest.trees_assigned)
+        ? rest.trees_assigned.filter((n: unknown): n is number => typeof n === "number")
+        : [];
+
+      const syncResult = await syncTreeAssignments(memberId, oldTrees, newTrees);
+      if (!syncResult.success) {
+        return NextResponse.json({ message: syncResult.error }, { status: 500 });
+      }
+    }
+
+    // Non-email fields: update the member row.
     if (Object.keys(rest).length > 0) {
-      const adminClient = await createServiceRoleClient();
       const { data, error } = await adminClient.from("members").update(rest).eq("id", memberId).select().single();
 
       if (error) {
@@ -105,7 +125,6 @@ export async function PUT(request: NextRequest, { params }: IParams) {
     }
 
     // Email-only update: re-fetch to return the updated row.
-    const adminClient = await createServiceRoleClient();
     const { data } = await adminClient.from("members").select("*").eq("id", memberId).single();
 
     return NextResponse.json({ data }, { status: 200 });

--- a/src/app/api/admin/members/route.ts
+++ b/src/app/api/admin/members/route.ts
@@ -2,6 +2,7 @@ import { createServerLevelClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 import { Database } from "@/database/database.types";
 import { hasOnlyAllowedKeys, isDate, isEmail, isPhone, postgrestErrorToHttpStatus } from "@/database/utils";
+import { syncTreeAssignments } from "@/lib/admin/members";
 
 type VolunteerRow = Database["public"]["Tables"]["members"]["Row"];
 type VolunteerInsert = Database["public"]["Tables"]["members"]["Insert"];
@@ -54,6 +55,10 @@ export async function POST(request: NextRequest) {
     if (error) {
       console.log("Supabase error creating volunteer:", error.message);
       return NextResponse.json({ message: error.message }, { status: postgrestErrorToHttpStatus(error) });
+    }
+
+    if (data && Array.isArray(body.trees_assigned) && body.trees_assigned.length > 0) {
+      await syncTreeAssignments(data.id, [], body.trees_assigned);
     }
 
     return NextResponse.json({ message: data }, { status: 201 });

--- a/src/app/api/admin/trees/[id]/route.ts
+++ b/src/app/api/admin/trees/[id]/route.ts
@@ -1,4 +1,4 @@
-import { createServerLevelClient } from "@/lib/supabase/server";
+import { createServerLevelClient, createServiceRoleClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 import { postgrestErrorToHttpStatus } from "@/database/utils";
 
@@ -56,6 +56,17 @@ export async function GET(req: NextRequest, { params }: IParams) {
 export async function PUT(req: NextRequest, { params }: IParams) {
   try {
     const supabase = await createServerLevelClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+    const { data: isAdminRow } = await supabase.rpc("is_admin");
+    if (!isAdminRow) {
+      return NextResponse.json({ message: "Forbidden" }, { status: 403 });
+    }
+
     const { id } = await params;
     const body = await req.json();
 
@@ -88,12 +99,53 @@ export async function PUT(req: NextRequest, { params }: IParams) {
 export async function DELETE(req: NextRequest, { params }: IParams) {
   try {
     const supabase = await createServerLevelClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+    const { data: isAdminRow } = await supabase.rpc("is_admin");
+    if (!isAdminRow) {
+      return NextResponse.json({ message: "Forbidden" }, { status: 403 });
+    }
+
     const { id } = await params;
     const { data, error } = await supabase.from("trees").delete().eq("id", id).limit(1).select().single();
 
     if (error) {
       const status = postgrestErrorToHttpStatus(error);
       return NextResponse.json({ message: error.message }, { status: status });
+    }
+
+    if (data && typeof data.ecoslo_num === "number") {
+      const adminClient = await createServiceRoleClient();
+      const ecosloNum = data.ecoslo_num;
+
+      const { data: affectedMembers, error: lookupError } = await adminClient
+        .from("members")
+        .select("id, trees_assigned")
+        .contains("trees_assigned", [ecosloNum]);
+
+      if (lookupError) {
+        console.error("[trees DELETE] failed to find members with deleted tree:", lookupError);
+      } else if (affectedMembers) {
+        for (const member of affectedMembers) {
+          const currentTrees: number[] = Array.isArray(member.trees_assigned)
+            ? member.trees_assigned.filter((n: unknown): n is number => typeof n === "number")
+            : [];
+          const cleaned = currentTrees.filter((n) => n !== ecosloNum);
+
+          const { error: cleanupError } = await adminClient
+            .from("members")
+            .update({ trees_assigned: cleaned, trees_count: cleaned.length })
+            .eq("id", member.id);
+
+          if (cleanupError) {
+            console.error("[trees DELETE] failed to clean up member", member.id, cleanupError);
+          }
+        }
+      }
     }
 
     return NextResponse.json({ message: data }, { status: 200 });

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -189,6 +189,7 @@ interface SelectProps {
   tableRef: MutableRefObject<Table<TreeSchema> | null>;
   onCheckedItem: (item: string) => void;
   triggerClassName?: string;
+  tableVersion?: number;
 }
 
 type SelectItem = {
@@ -221,8 +222,8 @@ function Select(props: SelectProps) {
     setItems((prev) => prev.map((entry) => (entry.id === item ? { ...entry, checked: !entry.checked } : entry)));
   };
 
-  const columnItems = items.length > 0 ? items : getItemsFromTable();
-  const hiddenCount = columnItems.filter((item) => !item.checked).length;
+  const freshItems = getItemsFromTable();
+  const hiddenCount = freshItems.filter((item) => !item.checked).length;
   const triggerLabel = hiddenCount === 0 ? "All Columns" : `${hiddenCount} Hidden`;
 
   return (
@@ -273,9 +274,10 @@ function Select(props: SelectProps) {
 
 interface ControlPanelProps {
   tableRef: MutableRefObject<Table<TreeSchema> | null>;
+  tableVersion?: number;
 }
 
-export default function ControlPanel({ tableRef }: ControlPanelProps) {
+export default function ControlPanel({ tableRef, tableVersion }: ControlPanelProps) {
   void tableRef;
 
   const CONTROL_STATUS_OPTIONS = ["All", "Active", "Graduated"];
@@ -354,6 +356,7 @@ export default function ControlPanel({ tableRef }: ControlPanelProps) {
           <Select
             label="Columns"
             tableRef={tableRef}
+            tableVersion={tableVersion}
             triggerClassName="w-full"
             checkedIcon={<Check />}
             onCheckedItem={(item: string) => tableRef.current?.setColumnVisibility(item, (visible) => !visible)}

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -7,7 +7,7 @@ interface LogoutButtonProps {
   children?: React.ReactNode;
 }
 
-export function LogoutButton({ className, children = "Log out" }: LogoutButtonProps) {
+export function LogoutButton({ className, children = "Logout" }: LogoutButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
 
   const handleLogout = async () => {

--- a/src/components/MapClient.tsx
+++ b/src/components/MapClient.tsx
@@ -65,9 +65,6 @@ function createTreeMarkerIcon(selected: boolean) {
   const pin = "var(--color-primary)";
   const white = "var(--color-card)";
   const black = "var(--color-text)";
-  const ring = selected
-    ? `0 0 0 4px ${white}, 0 5px 14px color-mix(in srgb, ${black} 28%, transparent)`
-    : `0 2px 6px color-mix(in srgb, ${black} 18%, transparent)`;
 
   return L.divIcon({
     className: "eco-tree-marker",
@@ -79,7 +76,6 @@ function createTreeMarkerIcon(selected: boolean) {
             position: "relative",
             width: `${MARKER_SIZE}px`,
             height: `${MARKER_SIZE}px`,
-            filter: `drop-shadow(0 2px 4px color-mix(in srgb, ${black} 18%, transparent))`,
           },
         },
         createElement(MapPin, {
@@ -87,7 +83,12 @@ function createTreeMarkerIcon(selected: boolean) {
           fill: pin,
           size: MARKER_SIZE,
           strokeWidth: 2.25,
-          style: { boxShadow: ring, borderRadius: selected ? "999px" : undefined },
+          style: selected
+            ? {
+                boxShadow: `0 0 0 4px ${white}, 0 5px 14px color-mix(in srgb, ${black} 28%, transparent)`,
+                borderRadius: "999px",
+              }
+            : undefined,
         }),
         createElement(TreeDeciduous, {
           color: white,
@@ -258,7 +259,7 @@ export default function MapClient() {
               </button>
             </div>
 
-            <div className="pointer-events-auto w-full max-w-md rounded-2xl border border-border bg-off-white px-5 py-4 shadow-map-control">
+            <div className="pointer-events-auto w-fit rounded-2xl border border-border bg-off-white px-5 py-4 shadow-map-control">
               <MapControlPanel trees={locations} onFilter={setFilteredLocations} onCenter={handleCenter} />
             </div>
           </div>

--- a/src/components/MapControlPanel.tsx
+++ b/src/components/MapControlPanel.tsx
@@ -97,6 +97,7 @@ function ControlStatusPills(props: ControlStatusPillsInterface) {
   return (
     <PillGroup
       activeValue={props.activeFilter}
+      className="flex-nowrap"
       options={props.options.map((option) => ({ label: option.label, value: option.value }))}
       onChange={(_, index) => handleSelect(index)}
     />
@@ -176,7 +177,7 @@ export default function ControlPanel(props: ControlPanelProps) {
         <ControlStatusPills
           options={[
             { label: "Active", value: Status.Active },
-            { label: "Off-boarded", value: Status.Graduated },
+            { label: "Graduated", value: Status.Graduated },
           ]}
           delay={0}
           delayFunction={(option) => {

--- a/src/components/MapPopout.tsx
+++ b/src/components/MapPopout.tsx
@@ -39,10 +39,6 @@ function displayValue(value: string | null | undefined) {
   return value?.trim() ? value : "Not available";
 }
 
-function displayStatus(status: string) {
-  return status === "Graduated" ? "Off-boarded" : status;
-}
-
 function statusBadgeVariant(status: string) {
   return status === "Active" ? "success" : "muted";
 }
@@ -168,7 +164,7 @@ export default function MapPopout({ tree, onClose }: MapPopoutProps) {
           <div className="flex flex-wrap items-center gap-3">
             <h2 className="font-serif text-3xl font-normal leading-none text-text">#{tree.id}</h2>
             <Badge variant={statusBadgeVariant(tree.status)} size="md">
-              {displayStatus(tree.status)}
+              {tree.status}
             </Badge>
           </div>
         </div>

--- a/src/components/MemberPageTableWidget.tsx
+++ b/src/components/MemberPageTableWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { type MutableRefObject, useEffect, useState } from "react";
 import { MemberSchema, memberColumns } from "./data-table/table-widget-defs";
 import { Table } from "./data-table/table/table-types";
 import MemberPageTable from "./data-table/member-page-table";
@@ -31,10 +31,12 @@ function MemberPageTableWidget({
   className,
   onRowClick,
   onTableReady,
+  refetchRef,
 }: {
   className?: string;
   onRowClick: (e: React.MouseEvent<HTMLTableRowElement, MouseEvent>, member: MemberSchema) => void;
   onTableReady?: (table: Table<MemberSchema>) => void;
+  refetchRef?: MutableRefObject<(() => void) | null>;
 }) {
   const [members, setMembers] = useState<MemberSchema[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -51,7 +53,7 @@ function MemberPageTableWidget({
           setError(null);
         }
       } catch (err) {
-        if (mounted) setError(err instanceof Error ? err.message : "Failed to load trees");
+        if (mounted) setError(err instanceof Error ? err.message : "Failed to load members");
       } finally {
         if (mounted) setIsLoading(false);
       }
@@ -61,6 +63,14 @@ function MemberPageTableWidget({
       mounted = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (!refetchRef) return;
+    refetchRef.current = async () => {
+      const data = await getAdminMembers();
+      setMembers(data);
+    };
+  }, [refetchRef]);
 
   return (
     <div className={`min-w-0 flex flex-col ${className || ""}`}>

--- a/src/components/TreePageTableWidget.tsx
+++ b/src/components/TreePageTableWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { type MutableRefObject, useEffect, useState } from "react";
 import { treeColumns, TreeSchema } from "./data-table/table-widget-defs";
 import { Table } from "./data-table/table/table-types";
 import TreePageTable from "./data-table/tree-page-table";
@@ -10,10 +10,12 @@ function TreePageTableWidget({
   className,
   onRowClick,
   onTableReady,
+  refetchRef,
 }: {
   className?: string;
   onRowClick: (e: React.MouseEvent<HTMLTableRowElement, MouseEvent>, tree: TreeSchema) => void;
   onTableReady?: (table: Table<TreeSchema>) => void;
+  refetchRef?: MutableRefObject<(() => void) | null>;
 }) {
   const [trees, setTrees] = useState<TreeSchema[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -40,6 +42,14 @@ function TreePageTableWidget({
       mounted = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (!refetchRef) return;
+    refetchRef.current = async () => {
+      const data = await getAdminTrees();
+      setTrees(data);
+    };
+  }, [refetchRef]);
 
   return (
     <div className={`min-w-0 flex flex-col ${className || ""}`}>

--- a/src/components/assigned-tree-picker-modal.tsx
+++ b/src/components/assigned-tree-picker-modal.tsx
@@ -1,19 +1,22 @@
 "use client";
 
-import { Modal, ModalClose, ModalContent, ModalDescription, ModalHeader } from "@/components/modal";
-import { SearchField, appButtonClassName } from "@/components/ui/form-controls";
+import { Modal, ModalClose, ModalContent, ModalDescription, ModalFooter, ModalHeader } from "@/components/modal";
+import { AppButton, SearchField, appButtonClassName } from "@/components/ui/form-controls";
 import Fuse from "fuse.js";
-import { X } from "lucide-react";
+import { ArrowRightLeft, X } from "lucide-react";
 import { useMemo, useState } from "react";
 
 export type AssignableTree = {
   common_name?: string | null;
   ecoslo_num: number;
   species_name?: string | null;
+  tree_keeper_id?: number | null;
+  tree_keeper?: { firstname: string; lastname: string } | null;
 };
 
 type AssignedTreePickerModalProps = {
   assignedTreeEcosloNumbers: number[];
+  currentMemberId: number | null;
   isLoading: boolean;
   onOpenChange: (open: boolean) => void;
   onSelectTree: (treeEcosloNumber: number) => void;
@@ -30,6 +33,7 @@ function getTreeDisplayName(tree: AssignableTree) {
 
 export default function AssignedTreePickerModal({
   assignedTreeEcosloNumbers,
+  currentMemberId,
   isLoading,
   onOpenChange,
   onSelectTree,
@@ -48,6 +52,7 @@ export default function AssignedTreePickerModal({
       >
         <AssignedTreePickerModalBody
           assignedTreeSet={assignedTreeSet}
+          currentMemberId={currentMemberId}
           isLoading={isLoading}
           onOpenChange={onOpenChange}
           onSelectTree={onSelectTree}
@@ -60,20 +65,28 @@ export default function AssignedTreePickerModal({
 
 type AssignedTreePickerModalBodyProps = {
   assignedTreeSet: Set<number>;
+  currentMemberId: number | null;
   isLoading: boolean;
   onOpenChange: (open: boolean) => void;
   onSelectTree: (treeEcosloNumber: number) => void;
   trees: AssignableTree[];
 };
 
+function getKeeperName(tree: AssignableTree) {
+  if (!tree.tree_keeper) return null;
+  return `${tree.tree_keeper.firstname} ${tree.tree_keeper.lastname}`.trim() || null;
+}
+
 function AssignedTreePickerModalBody({
   assignedTreeSet,
+  currentMemberId,
   isLoading,
   onOpenChange,
   onSelectTree,
   trees,
 }: AssignedTreePickerModalBodyProps) {
   const [searchQuery, setSearchQuery] = useState("");
+  const [transferConfirmTree, setTransferConfirmTree] = useState<AssignableTree | null>(null);
   const fuse = useMemo(
     () =>
       new Fuse(trees, {
@@ -92,8 +105,23 @@ function AssignedTreePickerModalBody({
     return [...trees].sort((firstTree, secondTree) => firstTree.ecoslo_num - secondTree.ecoslo_num);
   }, [fuse, searchQuery, trees]);
 
-  const handleTreeSelect = (treeEcosloNumber: number) => {
-    onSelectTree(treeEcosloNumber);
+  const handleTreeSelect = (tree: AssignableTree) => {
+    const isOwnedByAnother = tree.tree_keeper_id != null && tree.tree_keeper_id !== currentMemberId;
+
+    if (isOwnedByAnother) {
+      setTransferConfirmTree(tree);
+      return;
+    }
+
+    onSelectTree(tree.ecoslo_num);
+    onOpenChange(false);
+    setSearchQuery("");
+  };
+
+  const handleTransferConfirm = () => {
+    if (!transferConfirmTree) return;
+    onSelectTree(transferConfirmTree.ecoslo_num);
+    setTransferConfirmTree(null);
     onOpenChange(false);
     setSearchQuery("");
   };
@@ -125,6 +153,8 @@ function AssignedTreePickerModalBody({
           ) : filteredTrees.length > 0 ? (
             filteredTrees.map((tree) => {
               const isAssigned = assignedTreeSet.has(tree.ecoslo_num);
+              const otherKeeperName =
+                tree.tree_keeper_id != null && tree.tree_keeper_id !== currentMemberId ? getKeeperName(tree) : null;
 
               return (
                 <button
@@ -136,10 +166,14 @@ function AssignedTreePickerModalBody({
                   })}
                   disabled={isAssigned}
                   key={tree.ecoslo_num}
-                  onClick={() => handleTreeSelect(tree.ecoslo_num)}
+                  onClick={() => handleTreeSelect(tree)}
                 >
-                  <span>{`${getTreeDisplayName(tree)} #${tree.ecoslo_num}`}</span>
-                  {isAssigned ? <span className="text-sm text-text-muted ml-auto">Assigned</span> : null}
+                  <span className="flex-1">{`${getTreeDisplayName(tree)} #${tree.ecoslo_num}`}</span>
+                  {isAssigned ? (
+                    <span className="text-sm text-text-muted ml-auto shrink-0">Assigned</span>
+                  ) : otherKeeperName ? (
+                    <span className="text-sm text-info ml-auto shrink-0">{otherKeeperName}</span>
+                  ) : null}
                 </button>
               );
             })
@@ -150,6 +184,33 @@ function AssignedTreePickerModalBody({
           )}
         </div>
       </ModalDescription>
+
+      <Modal open={transferConfirmTree !== null} onOpenChange={() => setTransferConfirmTree(null)}>
+        <ModalContent className="bg-card" closeOnOverlayClick={false} showCloseButton={false} widthClassName="px-8">
+          <ModalHeader>
+            <div className="flex items-center justify-between gap-x-4">
+              <h2 className="w-full text-center text-2xl text-text-dark font-serif font-extrabold">Transfer Tree</h2>
+            </div>
+          </ModalHeader>
+          <ModalDescription className="flex flex-col gap-y-4 pt-1 pb-4">
+            <p className="w-full text-center text-text-muted">
+              {transferConfirmTree
+                ? `This tree is currently assigned to ${getKeeperName(transferConfirmTree) ?? "another member"}. Assigning it will transfer it from them.`
+                : ""}
+            </p>
+          </ModalDescription>
+          <ModalFooter>
+            <div className="w-full flex justify-center gap-x-4">
+              <AppButton type="button" variant="secondary" onClick={() => setTransferConfirmTree(null)}>
+                Cancel
+              </AppButton>
+              <AppButton icon={ArrowRightLeft} onClick={handleTransferConfirm} type="button">
+                Transfer
+              </AppButton>
+            </div>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </>
   );
 }

--- a/src/components/data-table/table-widget-defs.tsx
+++ b/src/components/data-table/table-widget-defs.tsx
@@ -331,8 +331,23 @@ export const treeColumns: ColumnDef<TreeSchema>[] = [
     accessorKey: "survey_logs",
     name: "Survey Logs",
     head: (table, name, columnId) => <HeadControls table={table} columnId={columnId} title={name} canSort={false} />,
-    cell: (value) => <p className="max-w-64 truncate">{String(value)}</p>,
-    canSearch: true,
+    cell: (value) => {
+      const surveyIds = Array.isArray(value) && value.every((id): id is number => typeof id === "number") ? value : [];
+
+      return (
+        <Badge shape="rounded" variant="muted">
+          {surveyIds.length > 0 ? (
+            <span className="flex justify-between gap-x-2 max-w-48">
+              <span className="truncate">{surveyIds.join(", ")}</span>
+              {surveyIds.length >= 5 && <span className="font-extrabold">{surveyIds.length}</span>}
+            </span>
+          ) : (
+            "None"
+          )}
+        </Badge>
+      );
+    },
+    canSearch: false,
   },
 ];
 

--- a/src/components/navbar/SideNavbar.tsx
+++ b/src/components/navbar/SideNavbar.tsx
@@ -5,11 +5,14 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  BarChart3,
+  ListChecks,
   Calendar,
   Ellipsis,
   LayoutDashboard,
+  LogIn,
+  LogOut,
   Map,
+  MapPin,
   NotebookPen,
   TreeDeciduous,
   UsersRound,
@@ -30,9 +33,9 @@ const allFeatureButtons: FeatureButton[] = [
   { icon: TreeDeciduous, label: "Trees", link: "/trees" },
   { icon: UsersRound, label: "Members", link: "/members", adminOnly: true },
   { icon: Calendar, label: "Reminders", link: "/reminders", adminOnly: true },
-  { icon: BarChart3, label: "Tasks", link: "/tasks" },
+  { icon: ListChecks, label: "Tasks", link: "/tasks" },
   { icon: NotebookPen, label: "Surveys", link: "/survey" },
-  { icon: Map, label: "Map", link: "/map" },
+  { icon: MapPin, label: "Map", link: "/map" },
 ];
 
 const NAV_ITEM_HEIGHT = 88;
@@ -118,7 +121,12 @@ export default function SideNavbar() {
     if (loading) return null;
 
     if (member) {
-      return <LogoutButton className={appButtonClassName({ className: "w-28", size: "sm", variant: "secondary" })} />;
+      return (
+        <LogoutButton className={appButtonClassName({ className: "w-28", size: "sm", variant: "secondary" })}>
+          <LogOut aria-hidden="true" className="h-4 w-4" strokeWidth={2} />
+          <span>Logout</span>
+        </LogoutButton>
+      );
     }
 
     if (pathname === "/login") {
@@ -133,7 +141,8 @@ export default function SideNavbar() {
     // Default for logged-out users on any other public page (notably /map).
     return (
       <Link href="/login" className={appButtonClassName({ className: "w-28", size: "sm", variant: "secondary" })}>
-        Login
+        <LogIn aria-hidden="true" className="h-4 w-4" strokeWidth={2} />
+        <span>Login</span>
       </Link>
     );
   })();

--- a/src/components/reminders/ReminderView.tsx
+++ b/src/components/reminders/ReminderView.tsx
@@ -11,6 +11,7 @@ import { useMemo, useState } from "react";
 import ReminderLongTextInput from "./ReminderLongTextInput";
 import ReminderToggleArea from "./ReminderToggleArea";
 import { reminderFieldLabelClass } from "./reminderInputStyles";
+import { Modal, ModalContent, ModalDescription, ModalFooter, ModalHeader } from "@/components/modal";
 import {
   createCronExpression,
   cronExpressionToFormValues,
@@ -95,6 +96,7 @@ export default function ReminderView({
   const [deleteError, setDeleteError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
   const isCreateMode = mode === "create";
   const isEditMode = mode === "edit";
   const isViewMode = mode === "view";
@@ -105,6 +107,7 @@ export default function ReminderView({
     ? assigneeLabel || "No assignees"
     : "Set up a new automated message for members";
   const submitLabel = isEditMode ? "Save Changes" : "Create Reminder";
+  const displayedReminderName = reminder?.name || form.name || "Reminder";
 
   const updateForm = <K extends keyof ReminderFormState>(key: K, value: ReminderFormState[K]) => {
     setForm((current) => ({ ...current, [key]: value }));
@@ -160,6 +163,7 @@ export default function ReminderView({
 
     try {
       await deleteReminder(reminder.id);
+      setDeleteConfirmationOpen(false);
       onDeleted?.(reminder.id);
     } catch (error) {
       setDeleteError(error instanceof Error ? error.message : "Unable to delete reminder.");
@@ -199,7 +203,10 @@ export default function ReminderView({
               iconOnly
               variant="ghost"
               disabled={isDeleting}
-              onClick={handleDelete}
+              onClick={() => {
+                setDeleteError("");
+                setDeleteConfirmationOpen(true);
+              }}
               type="button"
             >
               Delete reminder
@@ -232,7 +239,7 @@ export default function ReminderView({
       )}
       {!isViewMode && (
         <div className="flex flex-row gap-4">
-          <div className="flex basis-1/2  text-text-dark">
+          <div className="flex min-w-0 basis-1/2 text-text-dark">
             <ReminderDropdown
               disabled={isReadOnly}
               label="Type"
@@ -242,7 +249,7 @@ export default function ReminderView({
               onOptionClick={handleTemplateSelect}
             />
           </div>
-          <div className="flex flex-grow text-text-dark">
+          <div className="flex min-w-0 basis-1/2 text-text-dark">
             <ReminderNestedMultiSelectDropdown
               disabled={isReadOnly}
               label="Assignees"
@@ -387,6 +394,32 @@ export default function ReminderView({
           {submitError && <span className="font-mulish text-sm text-danger">{submitError}</span>}
         </>
       )}
+
+      <Modal open={deleteConfirmationOpen} onOpenChange={setDeleteConfirmationOpen}>
+        <ModalContent className="bg-card" closeOnOverlayClick={false} showCloseButton={false} widthClassName="px-8">
+          <ModalHeader>
+            <div className="flex items-center justify-between gap-x-4">
+              <h2 className="w-full text-center text-2xl text-text-dark font-serif font-extrabold">
+                {`Delete ${displayedReminderName}`}
+              </h2>
+            </div>
+          </ModalHeader>
+          <ModalDescription className="flex flex-col gap-y-4 pt-1 pb-4">
+            <p className="w-full text-center text-text-muted">This action cannot be undone.</p>
+            {deleteError ? <p className="text-destructive font-medium">{deleteError}</p> : null}
+          </ModalDescription>
+          <ModalFooter>
+            <div className="w-full flex justify-center gap-x-4">
+              <AppButton type="button" variant="secondary" onClick={() => setDeleteConfirmationOpen(false)}>
+                Cancel
+              </AppButton>
+              <AppButton variant="danger" disabled={isDeleting} onClick={handleDelete} type="button">
+                {isDeleting ? "Deleting..." : "Delete Reminder"}
+              </AppButton>
+            </div>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </div>
   );
 }

--- a/src/components/reminders/RemindersList.tsx
+++ b/src/components/reminders/RemindersList.tsx
@@ -20,7 +20,7 @@ export default function RemindersList({
   return (
     <div className="flex max-h-full min-h-0 flex-col gap-6 overflow-hidden rounded-xl border-1 border-border bg-table-row-dark p-6">
       <h2 className="font-serif text-[26px] font-normal leading-tight">Overview</h2>
-      <div className="min-h-0 no-scrollbar flex flex-1 flex-col gap-4 overflow-y-auto pr-1">
+      <div className="min-h-0 no-scrollbar flex flex-1 flex-col gap-4 overflow-y-auto rounded-xl">
         {reminders.length > 0 ? (
           reminders.map((reminder) => (
             <ReminderCard

--- a/src/components/tree-detail-modal.tsx
+++ b/src/components/tree-detail-modal.tsx
@@ -1,0 +1,870 @@
+"use client";
+
+import { TreeSchema } from "@/components/data-table/table-widget-defs";
+import { Modal, ModalClose, ModalContent, ModalDescription, ModalFooter, ModalHeader } from "@/components/modal";
+import {
+  AppButton,
+  appButtonClassName,
+  SelectField,
+  type SelectOption,
+  textFieldClassName,
+  textareaFieldClassName,
+} from "@/components/ui/form-controls";
+import { Database } from "@/database/database.types";
+import { createUserLevelClient } from "@/lib/supabase/client";
+import { Pencil, Trash2, Undo2, X } from "lucide-react";
+import { type ChangeEvent, type FormEvent, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import Badge from "@/components/badge";
+
+type Condition = Database["public"]["Enums"]["Condition"];
+type TreeStatus = Database["public"]["Enums"]["TreeStatus"];
+type WateringStatus = Database["public"]["Enums"]["WateringStatus"];
+type MulchingStatus = Database["public"]["Enums"]["MulchingStatus"];
+
+type TreeFormState = {
+  ecoslo_num: string;
+  species_name: string;
+  common_name: string;
+  funder: string;
+  date_planted: string;
+  condition: Condition;
+  address: string;
+  latitude: string;
+  longitude: string;
+  status: TreeStatus;
+  is_public: string;
+  next_watering_date: string;
+  weekly_watering_status: WateringStatus;
+  next_mulching_date: string;
+  yearly_mulching_status: MulchingStatus;
+  notes: string;
+  admin_notes: string;
+};
+
+type SurveyRow = {
+  id: number;
+  body: Record<string, unknown> | null;
+  created_at: string;
+};
+
+const conditionOptions: SelectOption[] = [
+  { label: "Good", value: "good" },
+  { label: "Fair", value: "fair" },
+  { label: "Poor", value: "poor" },
+];
+
+const statusOptions: SelectOption[] = [
+  { label: "Active", value: "Active" },
+  { label: "Graduated", value: "Graduated" },
+];
+
+const visibilityOptions: SelectOption[] = [
+  { label: "Public", value: "true" },
+  { label: "Private", value: "false" },
+];
+
+const wateringStatusOptions: SelectOption[] = [
+  { label: "Completed", value: "Completed" },
+  { label: "Pending", value: "Pending" },
+];
+
+const mulchingStatusOptions: SelectOption[] = [
+  { label: "Completed", value: "Completed" },
+  { label: "Pending", value: "Pending" },
+];
+
+function getCurrentDateInputValue() {
+  const today = new Date();
+  return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+}
+
+function createBlankTreeForm(): TreeFormState {
+  return {
+    ecoslo_num: "",
+    species_name: "",
+    common_name: "",
+    funder: "",
+    date_planted: getCurrentDateInputValue(),
+    condition: "good",
+    address: "",
+    latitude: "",
+    longitude: "",
+    status: "Active",
+    is_public: "false",
+    next_watering_date: "",
+    weekly_watering_status: "Pending",
+    next_mulching_date: "",
+    yearly_mulching_status: "Pending",
+    notes: "",
+    admin_notes: "",
+  };
+}
+
+function treeToForm(tree: TreeSchema): TreeFormState {
+  return {
+    ecoslo_num: tree.ecoslo_num != null ? String(tree.ecoslo_num) : "",
+    species_name: tree.species_name ?? "",
+    common_name: tree.common_name ?? "",
+    funder: tree.funder ?? "",
+    date_planted: tree.date_planted ?? "",
+    condition: tree.condition ?? "good",
+    address: tree.address ?? "",
+    latitude: tree.latitude != null ? String(tree.latitude) : "",
+    longitude: tree.longitude != null ? String(tree.longitude) : "",
+    status: tree.status ?? "Active",
+    is_public: String(tree.is_public ?? false),
+    next_watering_date: tree.next_watering_date ?? "",
+    weekly_watering_status: tree.weekly_watering_status ?? "Pending",
+    next_mulching_date: tree.next_mulching_date ?? "",
+    yearly_mulching_status: tree.yearly_mulching_status ?? "Pending",
+    notes: tree.notes ?? "",
+    admin_notes: tree.admin_notes ?? "",
+  };
+}
+
+function normalizeTreeForm(form: TreeFormState): TreeFormState {
+  return {
+    ...form,
+    ecoslo_num: form.ecoslo_num.trim(),
+    species_name: form.species_name.trim(),
+    common_name: form.common_name.trim(),
+    funder: form.funder.trim(),
+    date_planted: form.date_planted.trim(),
+    address: form.address.trim(),
+    latitude: form.latitude.trim(),
+    longitude: form.longitude.trim(),
+    notes: form.notes.trim(),
+    admin_notes: form.admin_notes.trim(),
+  };
+}
+
+function treeFormsMatch(a: TreeFormState, b: TreeFormState): boolean {
+  const na = normalizeTreeForm(a);
+  const nb = normalizeTreeForm(b);
+  return (
+    na.ecoslo_num === nb.ecoslo_num &&
+    na.species_name === nb.species_name &&
+    na.common_name === nb.common_name &&
+    na.funder === nb.funder &&
+    na.date_planted === nb.date_planted &&
+    na.condition === nb.condition &&
+    na.address === nb.address &&
+    na.latitude === nb.latitude &&
+    na.longitude === nb.longitude &&
+    na.status === nb.status &&
+    na.is_public === nb.is_public &&
+    na.next_watering_date === nb.next_watering_date &&
+    na.weekly_watering_status === nb.weekly_watering_status &&
+    na.next_mulching_date === nb.next_mulching_date &&
+    na.yearly_mulching_status === nb.yearly_mulching_status &&
+    na.notes === nb.notes &&
+    na.admin_notes === nb.admin_notes
+  );
+}
+
+function display(value: unknown): string {
+  if (value === null || value === undefined || value === "") return "N/A";
+  return String(value);
+}
+
+function conditionBadgeVariant(condition: string) {
+  switch (condition.toLowerCase()) {
+    case "good":
+      return "success" as const;
+    case "fair":
+      return "warning" as const;
+    case "poor":
+      return "danger" as const;
+    default:
+      return "muted" as const;
+  }
+}
+
+type TreeDetailModalProps = {
+  tree: TreeSchema | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+};
+
+export default function TreeDetailModal({ tree, open, onOpenChange, onSaved }: TreeDetailModalProps) {
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      {open && (
+        <TreeDetailModalContent key={tree?.id ?? "new"} tree={tree} onOpenChange={onOpenChange} onSaved={onSaved} />
+      )}
+    </Modal>
+  );
+}
+
+function TreeDetailModalContent({ tree, onOpenChange, onSaved }: Omit<TreeDetailModalProps, "open">) {
+  const [treeForm, setTreeForm] = useState<TreeFormState>(() => (tree ? treeToForm(tree) : createBlankTreeForm()));
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isEditing, setIsEditing] = useState(!tree);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
+  const [duplicateEcosloNum, setDuplicateEcosloNum] = useState<number | null>(null);
+
+  const [surveys, setSurveys] = useState<SurveyRow[]>([]);
+
+  const initialTreeForm = tree ? treeToForm(tree) : createBlankTreeForm();
+  const hasFormChanges = !treeFormsMatch(treeForm, initialTreeForm);
+
+  const isAddingTree = tree === null;
+  const displayedTitle = tree ? `ECOSLO #${tree.ecoslo_num}` : "Add Tree";
+
+  const treeKeeper = tree?.tree_keeper ?? null;
+  const hasKeeper = treeKeeper != null && treeKeeper.name.trim().length > 0;
+
+  useEffect(() => {
+    const surveyIds = tree?.survey_logs;
+    if (!surveyIds?.length) return;
+
+    let cancelled = false;
+
+    async function loadSurveys() {
+      const supabase = createUserLevelClient();
+      const { data } = await supabase
+        .from("surveys")
+        .select("id, body, created_at")
+        .in("id", surveyIds!)
+        .order("id", { ascending: true });
+
+      if (!cancelled) setSurveys((data ?? []) as SurveyRow[]);
+    }
+
+    void loadSurveys();
+    return () => {
+      cancelled = true;
+    };
+  }, [tree?.id, tree?.survey_logs]);
+
+  const handleFormChange = (field: keyof TreeFormState) => {
+    return (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setTreeForm((current) => ({ ...current, [field]: event.target.value }));
+    };
+  };
+
+  const handleSelectChange = (field: keyof TreeFormState) => {
+    return (value: string) => {
+      setTreeForm((current) => ({ ...current, [field]: value }));
+    };
+  };
+
+  const handleDelete = async () => {
+    if (!tree) return;
+
+    setIsDeleting(true);
+    setDeleteError(null);
+
+    try {
+      const response = await fetch(`/api/admin/trees/${tree.id}`, { method: "DELETE" });
+      const body = (await response.json().catch(() => null)) as { message?: unknown; error?: unknown } | null;
+
+      if (!response.ok) {
+        throw new Error(
+          typeof body?.message === "string"
+            ? body.message
+            : typeof body?.error === "string"
+              ? (body.error as string)
+              : "Failed to delete tree",
+        );
+      }
+
+      setDeleteConfirmationOpen(false);
+      onSaved();
+      onOpenChange(false);
+    } catch (error) {
+      setDeleteError(error instanceof Error ? error.message : "Failed to delete tree");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!hasFormChanges) return;
+
+    const normalized = normalizeTreeForm(treeForm);
+    const ecosloNum = normalized.ecoslo_num ? parseInt(normalized.ecoslo_num, 10) : null;
+
+    setIsSubmitting(true);
+    setFormError(null);
+
+    if (ecosloNum != null) {
+      const supabase = createUserLevelClient();
+      const { data: existing } = await supabase.from("trees").select("id").eq("ecoslo_num", ecosloNum).maybeSingle();
+
+      if (existing && existing.id !== tree?.id) {
+        setDuplicateEcosloNum(ecosloNum);
+        setIsSubmitting(false);
+        return;
+      }
+    }
+
+    const payload = {
+      ecoslo_num: ecosloNum,
+      species_name: normalized.species_name,
+      common_name: normalized.common_name,
+      funder: normalized.funder,
+      date_planted: normalized.date_planted,
+      condition: normalized.condition,
+      address: normalized.address,
+      latitude: normalized.latitude ? parseFloat(normalized.latitude) : 0,
+      longitude: normalized.longitude ? parseFloat(normalized.longitude) : 0,
+      status: normalized.status,
+      is_public: normalized.is_public === "true",
+      next_watering_date: normalized.next_watering_date || null,
+      weekly_watering_status: normalized.weekly_watering_status,
+      next_mulching_date: normalized.next_mulching_date || null,
+      yearly_mulching_status: normalized.yearly_mulching_status,
+      notes: normalized.notes || null,
+      admin_notes: normalized.admin_notes,
+    };
+
+    try {
+      const response = await fetch(isAddingTree ? "/api/admin/trees" : `/api/admin/trees/${tree.id}`, {
+        method: isAddingTree ? "POST" : "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const body = (await response.json().catch(() => null)) as { message?: unknown; error?: unknown } | null;
+
+      if (!response.ok) {
+        throw new Error(
+          typeof body?.message === "string"
+            ? body.message
+            : typeof body?.error === "string"
+              ? (body.error as string)
+              : "Failed to save tree",
+        );
+      }
+
+      onSaved();
+      onOpenChange(false);
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : "Failed to save tree");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <ModalContent
+        className="bg-off-white"
+        closeOnOverlayClick={false}
+        showCloseButton={false}
+        widthClassName="w-full max-w-xl"
+      >
+        <form onSubmit={handleSubmit}>
+          <ModalHeader className="flex flex-col gap-y-4">
+            <div className="flex items-center justify-between gap-x-4">
+              <div className="flex gap-x-4 items-center">
+                <h2 className="text-[1.75rem] text-text-dark font-serif font-extrabold">{displayedTitle}</h2>
+              </div>
+              <div className="flex gap-x-2">
+                <button
+                  type="button"
+                  className={appButtonClassName({ iconOnly: true, variant: "ghost" })}
+                  disabled={isAddingTree}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setIsEditing((current) => !current);
+                  }}
+                >
+                  {isEditing ? (
+                    <Undo2 className="w-5 h-5 text-text-muted" />
+                  ) : (
+                    <Pencil className="w-5 h-5 text-text-muted" />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  className={appButtonClassName({ iconOnly: true, variant: "ghost" })}
+                  disabled={isAddingTree}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setDeleteError(null);
+                    setDeleteConfirmationOpen(true);
+                  }}
+                >
+                  <Trash2 className="w-5 h-5 text-destructive" />
+                </button>
+                <ModalClose asChild>
+                  <button
+                    type="button"
+                    className={appButtonClassName({ iconOnly: true, variant: "ghost" })}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onOpenChange(false);
+                    }}
+                  >
+                    <X className="w-5 h-5 text-text-muted" />
+                  </button>
+                </ModalClose>
+              </div>
+            </div>
+            <div className="bg-border h-px w-full" />
+          </ModalHeader>
+
+          <ModalDescription className="flex flex-col gap-y-4 py-4 overflow-y-auto max-h-[70vh]">
+            {/* Tree Information */}
+            <div className="bg-foreground p-4 border border-border rounded-xl">
+              <p className="text-lg font-serif font-bold text-text-dark pb-2">Tree Information</p>
+              <div className="flex flex-col gap-y-4">
+                <div className="flex gap-x-4">
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">
+                      <span>ECOSLO #</span>
+                      {isEditing && <span className="text-destructive font-semibold"> *</span>}
+                    </p>
+                    {isEditing ? (
+                      <input
+                        type="number"
+                        className={cn(textFieldClassName, "bg-button-muted")}
+                        onChange={handleFormChange("ecoslo_num")}
+                        placeholder="EcoSLO number..."
+                        required
+                        min={1}
+                        value={treeForm.ecoslo_num}
+                      />
+                    ) : (
+                      <p className="text-text-dark font-medium">{display(treeForm.ecoslo_num)}</p>
+                    )}
+                  </div>
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">Visibility</p>
+                    {isEditing ? (
+                      <SelectField
+                        className="bg-button-muted"
+                        onChange={handleSelectChange("is_public")}
+                        options={visibilityOptions}
+                        value={treeForm.is_public}
+                      />
+                    ) : (
+                      <Badge variant={treeForm.is_public === "true" ? "info" : "muted"}>
+                        {treeForm.is_public === "true" ? "Public" : "Private"}
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+                <div className="flex gap-x-4">
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">
+                      <span>Species</span>
+                      {isEditing && <span className="text-destructive font-semibold"> *</span>}
+                    </p>
+                    {isEditing ? (
+                      <input
+                        className={cn(textFieldClassName, "bg-button-muted")}
+                        onChange={handleFormChange("species_name")}
+                        placeholder="Species name..."
+                        required
+                        value={treeForm.species_name}
+                      />
+                    ) : (
+                      <p className="text-text-dark font-medium">{display(treeForm.species_name)}</p>
+                    )}
+                  </div>
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">
+                      <span>Common Name</span>
+                      {isEditing && <span className="text-destructive font-semibold"> *</span>}
+                    </p>
+                    {isEditing ? (
+                      <input
+                        className={cn(textFieldClassName, "bg-button-muted")}
+                        onChange={handleFormChange("common_name")}
+                        placeholder="Common name..."
+                        required
+                        value={treeForm.common_name}
+                      />
+                    ) : (
+                      <p className="text-text-dark font-medium">{display(treeForm.common_name)}</p>
+                    )}
+                  </div>
+                </div>
+                <div className="flex gap-x-4">
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">
+                      <span>Funder</span>
+                      {isEditing && <span className="text-destructive font-semibold"> *</span>}
+                    </p>
+                    {isEditing ? (
+                      <input
+                        className={cn(textFieldClassName, "bg-button-muted")}
+                        onChange={handleFormChange("funder")}
+                        placeholder="Funder..."
+                        required
+                        value={treeForm.funder}
+                      />
+                    ) : (
+                      <p className="text-text-dark font-medium">{display(treeForm.funder)}</p>
+                    )}
+                  </div>
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">
+                      <span>Date Planted</span>
+                      {isEditing && <span className="text-destructive font-semibold"> *</span>}
+                    </p>
+                    {isEditing ? (
+                      <input
+                        type="date"
+                        className={cn(textFieldClassName, "bg-button-muted")}
+                        onChange={handleFormChange("date_planted")}
+                        required
+                        value={treeForm.date_planted}
+                      />
+                    ) : (
+                      <p className="text-text-dark font-medium">{display(treeForm.date_planted)}</p>
+                    )}
+                  </div>
+                </div>
+                <div className="flex gap-x-4">
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">Condition</p>
+                    {isEditing ? (
+                      <SelectField
+                        className="bg-button-muted"
+                        onChange={handleSelectChange("condition")}
+                        options={conditionOptions}
+                        value={treeForm.condition}
+                      />
+                    ) : (
+                      <Badge variant={conditionBadgeVariant(treeForm.condition)} textCase="capitalize">
+                        {treeForm.condition}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">Status</p>
+                    {isEditing ? (
+                      <SelectField
+                        className="bg-button-muted"
+                        onChange={handleSelectChange("status")}
+                        options={statusOptions}
+                        value={treeForm.status}
+                      />
+                    ) : (
+                      <Badge variant={treeForm.status === "Active" ? "success" : "muted"} textCase="capitalize">
+                        {treeForm.status}
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Location */}
+            <div className="bg-foreground p-4 border border-border rounded-xl">
+              <p className="text-lg font-serif font-bold text-text-dark pb-2">Location</p>
+              <div className="flex flex-col gap-y-4">
+                <div className="flex flex-col items-start gap-y-1">
+                  <p className="text-text-muted font-semibold">
+                    <span>Address</span>
+                    {isEditing && <span className="text-destructive font-semibold"> *</span>}
+                  </p>
+                  {isEditing ? (
+                    <input
+                      className={cn(textFieldClassName, "bg-button-muted")}
+                      onChange={handleFormChange("address")}
+                      placeholder="Street address..."
+                      required
+                      value={treeForm.address}
+                    />
+                  ) : (
+                    <p className="text-text-dark font-medium">{display(treeForm.address)}</p>
+                  )}
+                </div>
+                <div className="flex gap-x-4">
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">
+                      <span>Latitude</span>
+                      {isEditing && <span className="text-destructive font-semibold"> *</span>}
+                    </p>
+                    {isEditing ? (
+                      <input
+                        type="number"
+                        step="any"
+                        className={cn(textFieldClassName, "bg-button-muted")}
+                        onChange={handleFormChange("latitude")}
+                        placeholder="35.2828..."
+                        required
+                        value={treeForm.latitude}
+                      />
+                    ) : (
+                      <p className="text-text-dark font-medium">{display(treeForm.latitude)}</p>
+                    )}
+                  </div>
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">
+                      <span>Longitude</span>
+                      {isEditing && <span className="text-destructive font-semibold"> *</span>}
+                    </p>
+                    {isEditing ? (
+                      <input
+                        type="number"
+                        step="any"
+                        className={cn(textFieldClassName, "bg-button-muted")}
+                        onChange={handleFormChange("longitude")}
+                        placeholder="-120.6596..."
+                        required
+                        value={treeForm.longitude}
+                      />
+                    ) : (
+                      <p className="text-text-dark font-medium">{display(treeForm.longitude)}</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Treekeeper Info (read-only) */}
+            {!isAddingTree && (
+              <div className="bg-foreground p-4 border border-border rounded-xl">
+                <p className="text-lg font-serif font-bold text-text-dark pb-2">Treekeeper Info</p>
+                {hasKeeper ? (
+                  <div className="flex flex-col gap-y-4">
+                    <div className="flex flex-col items-start gap-y-1">
+                      <p className="text-text-muted font-semibold">Name</p>
+                      <p className="text-text-dark font-medium">{treeKeeper!.name}</p>
+                    </div>
+                    <div className="flex gap-x-4">
+                      <div className="flex-1 flex flex-col items-start gap-y-1">
+                        <p className="text-text-muted font-semibold">Phone</p>
+                        <p className="text-text-dark font-medium">
+                          {treeKeeper!.phone ? (
+                            treeKeeper!.phone
+                          ) : (
+                            <span className="text-text-muted">None provided</span>
+                          )}
+                        </p>
+                      </div>
+                      <div className="flex-1 flex flex-col items-start gap-y-1">
+                        <p className="text-text-muted font-semibold">Email</p>
+                        <p className="text-text-dark font-medium">
+                          {treeKeeper!.email ? (
+                            treeKeeper!.email
+                          ) : (
+                            <span className="text-text-muted">None provided</span>
+                          )}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-text-muted font-medium">No tree keeper assigned</p>
+                )}
+              </div>
+            )}
+
+            {/* Maintenance */}
+            <div className="bg-foreground p-4 border border-border rounded-xl">
+              <p className="text-lg font-serif font-bold text-text-dark pb-2">Maintenance</p>
+              <div className="flex flex-col gap-y-4">
+                <div className="flex gap-x-4">
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">Next Watering Date</p>
+                    {isEditing ? (
+                      <input
+                        type="date"
+                        className={cn(textFieldClassName, "bg-button-muted")}
+                        onChange={handleFormChange("next_watering_date")}
+                        value={treeForm.next_watering_date}
+                      />
+                    ) : (
+                      <p className="text-text-dark font-medium">{display(treeForm.next_watering_date)}</p>
+                    )}
+                  </div>
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">Watering Status</p>
+                    {isEditing ? (
+                      <SelectField
+                        className="bg-button-muted"
+                        onChange={handleSelectChange("weekly_watering_status")}
+                        options={wateringStatusOptions}
+                        value={treeForm.weekly_watering_status}
+                      />
+                    ) : (
+                      <p className="text-text-dark font-medium">{display(treeForm.weekly_watering_status)}</p>
+                    )}
+                  </div>
+                </div>
+                <div className="flex gap-x-4">
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">Next Mulching Date</p>
+                    {isEditing ? (
+                      <input
+                        type="date"
+                        className={cn(textFieldClassName, "bg-button-muted")}
+                        onChange={handleFormChange("next_mulching_date")}
+                        value={treeForm.next_mulching_date}
+                      />
+                    ) : (
+                      <p className="text-text-dark font-medium">{display(treeForm.next_mulching_date)}</p>
+                    )}
+                  </div>
+                  <div className="flex-1 flex flex-col items-start gap-y-1">
+                    <p className="text-text-muted font-semibold">Mulching Status</p>
+                    {isEditing ? (
+                      <SelectField
+                        className="bg-button-muted"
+                        onChange={handleSelectChange("yearly_mulching_status")}
+                        options={mulchingStatusOptions}
+                        value={treeForm.yearly_mulching_status}
+                      />
+                    ) : (
+                      <p className="text-text-dark font-medium">{display(treeForm.yearly_mulching_status)}</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Notes */}
+            <div className="bg-foreground p-4 border border-border rounded-xl">
+              <p className="text-lg font-serif font-bold text-text-dark pb-2">Notes</p>
+              <div className="flex flex-col gap-y-4">
+                <div className="flex flex-col items-start gap-y-1">
+                  <p className="text-text-muted font-semibold">General</p>
+                  {isEditing ? (
+                    <textarea
+                      className={cn(textareaFieldClassName, "bg-button-muted min-h-[80px]")}
+                      onChange={handleFormChange("notes")}
+                      placeholder="Notes..."
+                      value={treeForm.notes}
+                    />
+                  ) : (
+                    <p className="text-text-dark font-medium whitespace-pre-wrap">{display(treeForm.notes)}</p>
+                  )}
+                </div>
+                <div className="flex flex-col items-start gap-y-1">
+                  <p className="text-text-muted font-semibold">Admin</p>
+                  {isEditing ? (
+                    <textarea
+                      className={cn(textareaFieldClassName, "bg-button-muted min-h-[80px]")}
+                      onChange={handleFormChange("admin_notes")}
+                      placeholder="Admin notes..."
+                      value={treeForm.admin_notes}
+                    />
+                  ) : (
+                    <p className="text-text-dark font-medium whitespace-pre-wrap">{display(treeForm.admin_notes)}</p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Surveys (read-only) */}
+            {!isAddingTree && (
+              <div className="bg-foreground p-4 border border-border rounded-xl">
+                <p className="text-lg font-serif font-bold text-text-dark pb-2">Surveys</p>
+                {surveys.length === 0 ? (
+                  <p className="text-text-muted font-medium">No associated surveys</p>
+                ) : (
+                  <div className="flex flex-col gap-y-3">
+                    {surveys.map((survey) => {
+                      const body = survey.body ?? {};
+                      return (
+                        <div key={survey.id} className="rounded-xl border border-border bg-off-white p-3 text-sm">
+                          <p className="font-semibold text-text-dark">
+                            {new Date(survey.created_at).toLocaleDateString()}
+                          </p>
+                          <p className="text-text">Issue: {display(body.issue)}</p>
+                          <p className="text-text">Other: {display(body.issueOther)}</p>
+                          <p className="text-text">Image Link: {display(body.imageLink)}</p>
+                          <p className="text-text">Admin Contact: {display(body.adminContact)}</p>
+                          <div className="mt-3 max-h-40 overflow-y-auto whitespace-pre-wrap break-words">
+                            <p className="font-semibold text-text-dark">Notes</p>
+                            <p className="text-text">{display(body.notes)}</p>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {formError ? <p className="text-destructive font-medium">{formError}</p> : null}
+          </ModalDescription>
+
+          <ModalFooter>
+            <div className="flex flex-col w-full gap-y-4">
+              <div className="bg-border h-px w-full" />
+              <div className="flex justify-end gap-x-4">
+                <AppButton
+                  type="button"
+                  variant="secondary"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onOpenChange(false);
+                  }}
+                >
+                  Cancel
+                </AppButton>
+                <AppButton disabled={isSubmitting || !hasFormChanges} type="submit">
+                  {isAddingTree ? "Add Tree" : "Save Changes"}
+                </AppButton>
+              </div>
+            </div>
+          </ModalFooter>
+        </form>
+      </ModalContent>
+
+      <Modal open={duplicateEcosloNum !== null} onOpenChange={() => setDuplicateEcosloNum(null)}>
+        <ModalContent className="bg-card" closeOnOverlayClick={false} showCloseButton={false} widthClassName="px-8">
+          <ModalHeader>
+            <div className="flex items-center justify-between gap-x-4">
+              <h2 className="w-full text-center text-2xl text-text-dark font-serif font-extrabold">
+                Duplicate ECOSLO #
+              </h2>
+            </div>
+          </ModalHeader>
+          <ModalDescription className="flex flex-col gap-y-4 pt-1 pb-4">
+            <p className="w-full text-center text-text-muted">
+              {`ECOSLO #${duplicateEcosloNum} is already assigned to another tree. Please use a different number.`}
+            </p>
+          </ModalDescription>
+          <ModalFooter>
+            <div className="w-full flex justify-center">
+              <AppButton type="button" onClick={() => setDuplicateEcosloNum(null)}>
+                OK
+              </AppButton>
+            </div>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      <Modal open={deleteConfirmationOpen} onOpenChange={setDeleteConfirmationOpen}>
+        <ModalContent className="bg-card" closeOnOverlayClick={false} showCloseButton={false} widthClassName="px-8">
+          <ModalHeader>
+            <div className="flex items-center justify-between gap-x-4">
+              <h2 className="w-full text-center text-2xl text-text-dark font-serif font-extrabold">
+                {`Delete Tree #${tree?.ecoslo_num ?? ""}`}
+              </h2>
+            </div>
+          </ModalHeader>
+          <ModalDescription className="flex flex-col gap-y-4 pt-1 pb-4">
+            <p className="w-full text-center text-text-muted">This action cannot be undone.</p>
+            {deleteError ? <p className="text-destructive font-medium">{deleteError}</p> : null}
+          </ModalDescription>
+          <ModalFooter>
+            <div className="w-full flex justify-center gap-x-4">
+              <AppButton type="button" variant="secondary" onClick={() => setDeleteConfirmationOpen(false)}>
+                Cancel
+              </AppButton>
+              <AppButton variant="danger" disabled={isDeleting} onClick={handleDelete} type="button">
+                {isDeleting ? "Deleting..." : "Delete Tree"}
+              </AppButton>
+            </div>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/volunteer-page-form.tsx
+++ b/src/components/volunteer-page-form.tsx
@@ -38,11 +38,7 @@ type AssignedTreeResponse = {
 function isAssignableTree(value: unknown): value is AssignableTree {
   if (!value || typeof value !== "object") return false;
 
-  const tree = value as {
-    ecoslo_num?: number | null;
-    species_name?: string | null;
-    common_name?: string | null;
-  };
+  const tree = value as Record<string, unknown>;
 
   return typeof tree.ecoslo_num === "number";
 }
@@ -367,7 +363,6 @@ function VolunteerPageFormContent({ member, onOpenChange, onSaved }: Omit<Volunt
             <div className="flex items-center justify-between gap-x-4">
               <div className="flex gap-x-4 items-center">
                 <h2 className="text-[1.75rem] text-text-dark font-serif font-extrabold capitalize">{displayedName}</h2>
-                <MemberRoleBadge role={displayedRole} />
               </div>
               <div className="flex gap-x-2">
                 <button
@@ -387,7 +382,10 @@ function VolunteerPageFormContent({ member, onOpenChange, onSaved }: Omit<Volunt
                 </button>
                 <button
                   type="button"
-                  className={appButtonClassName({ iconOnly: true, variant: "danger" })}
+                  className={appButtonClassName({
+                    iconOnly: true,
+                    variant: "ghost",
+                  })}
                   disabled={isAddingMember}
                   onClick={(event) => {
                     event.stopPropagation();
@@ -415,7 +413,7 @@ function VolunteerPageFormContent({ member, onOpenChange, onSaved }: Omit<Volunt
           </ModalHeader>
           <ModalDescription className="flex flex-col gap-y-4 py-4 overflow-y-auto max-h-[70vh]">
             <div className="bg-foreground p-4 border border-border rounded-xl">
-              <p className="text-lg font-serif font-bold text-text-dark pb-4">Contact Information</p>
+              <p className="text-lg font-serif font-bold text-text-dark pb-2">Contact Information</p>
               <div className="flex flex-col gap-y-4">
                 <div className="flex gap-x-4">
                   <div className="flex-1 flex flex-col items-start gap-y-1">
@@ -582,7 +580,7 @@ function VolunteerPageFormContent({ member, onOpenChange, onSaved }: Omit<Volunt
                               onClick={() => handleAssignedTreeRemove(treeEcosloNumber)}
                               aria-label={`Remove assigned tree #${treeEcosloNumber}`}
                             >
-                              <Trash2 className="h-5 w-5" />
+                              <Trash2 className="h-5 w-5 text-destructive" />
                             </button>
                           ) : null}
                         </div>
@@ -636,13 +634,7 @@ function VolunteerPageFormContent({ member, onOpenChange, onSaved }: Omit<Volunt
               <AppButton type="button" variant="secondary" onClick={() => setDeleteConfirmationOpen(false)}>
                 Cancel
               </AppButton>
-              <AppButton
-                icon={Trash2}
-                variant="danger"
-                disabled={isDeleting}
-                onClick={handleDeleteVolunteer}
-                type="button"
-              >
+              <AppButton variant="danger" disabled={isDeleting} onClick={handleDeleteVolunteer} type="button">
                 {isDeleting ? "Deleting..." : "Delete Member"}
               </AppButton>
             </div>
@@ -652,6 +644,7 @@ function VolunteerPageFormContent({ member, onOpenChange, onSaved }: Omit<Volunt
 
       <VolunteerAssignedTreePickerModal
         assignedTreeEcosloNumbers={memberForm.assignedTreeEcosloNumbers}
+        currentMemberId={member?.id ?? null}
         isLoading={areAssignedTreesLoading}
         onOpenChange={setIsTreePickerOpen}
         onSelectTree={handleAssignedTreeAdd}

--- a/src/lib/admin/members.ts
+++ b/src/lib/admin/members.ts
@@ -4,6 +4,83 @@ type UpdateMemberEmailResult =
   | { success: true }
   | { success: false; error: string; code: "not_found" | "email_taken" | "auth_failed" | "members_failed" };
 
+type SyncTreeAssignmentsResult = { success: true } | { success: false; error: string };
+
+/**
+ * Syncs `trees.tree_keeper_id` and other members' `trees_assigned` arrays
+ * to reflect a change in this member's assigned trees.
+ *
+ * For removed trees: nullifies `tree_keeper_id`.
+ * For added trees: sets `tree_keeper_id` to this member, and removes
+ * the tree from any other member that previously had it.
+ */
+export async function syncTreeAssignments(
+  memberId: number,
+  oldTreeEcosloNumbers: number[],
+  newTreeEcosloNumbers: number[],
+): Promise<SyncTreeAssignmentsResult> {
+  const oldSet = new Set(oldTreeEcosloNumbers);
+  const newSet = new Set(newTreeEcosloNumbers);
+
+  const removed = oldTreeEcosloNumbers.filter((n) => !newSet.has(n));
+  const added = newTreeEcosloNumbers.filter((n) => !oldSet.has(n));
+
+  if (removed.length === 0 && added.length === 0) return { success: true };
+
+  const supabase = await createServiceRoleClient();
+
+  if (removed.length > 0) {
+    const { error } = await supabase.from("trees").update({ tree_keeper_id: null }).in("ecoslo_num", removed);
+
+    if (error) {
+      console.error("[syncTreeAssignments] failed to nullify tree_keeper_id for removed trees:", error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  if (added.length > 0) {
+    const { error: setKeeperError } = await supabase
+      .from("trees")
+      .update({ tree_keeper_id: memberId })
+      .in("ecoslo_num", added);
+
+    if (setKeeperError) {
+      console.error("[syncTreeAssignments] failed to set tree_keeper_id for added trees:", setKeeperError);
+      return { success: false, error: setKeeperError.message };
+    }
+
+    const { data: affectedMembers, error: lookupError } = await supabase
+      .from("members")
+      .select("id, trees_assigned")
+      .neq("id", memberId)
+      .overlaps("trees_assigned", added);
+
+    if (lookupError) {
+      console.error("[syncTreeAssignments] failed to find other members with overlapping trees:", lookupError);
+      return { success: false, error: lookupError.message };
+    }
+
+    const addedSet = new Set(added);
+    for (const other of affectedMembers ?? []) {
+      const currentTrees: number[] = Array.isArray(other.trees_assigned)
+        ? other.trees_assigned.filter((n): n is number => typeof n === "number")
+        : [];
+      const cleaned = currentTrees.filter((n) => !addedSet.has(n));
+
+      const { error: cleanupError } = await supabase
+        .from("members")
+        .update({ trees_assigned: cleaned, trees_count: cleaned.length })
+        .eq("id", other.id);
+
+      if (cleanupError) {
+        console.error("[syncTreeAssignments] failed to clean up member", other.id, cleanupError);
+      }
+    }
+  }
+
+  return { success: true };
+}
+
 /**
  * Updates a member's email, keeping auth.users.email in sync if the
  * member has already signed in (i.e., has a linked user_id).


### PR DESCRIPTION
## Developer: Matthew Blam

  ## Overview

  `matts-features` is one commit ahead of `develop`:

  `1516d8e feat: trees page functionality, CSV feature cleanup and fixes, map
  page cleanup and fixes`

  Diff size: `23 files changed, 1328 insertions, 146 deletions`.

  ## Added

  ### `src/components/tree-detail-modal.tsx`

  - New admin tree detail modal.
  - Supports viewing, adding, editing, and deleting trees.
  - Includes duplicate ECOSLO number guard.
  - Shows tree keeper info, maintenance fields, notes/admin notes, visibility/
  status/condition, and related survey logs.
  - Adds delete confirmation modal.

  ### `src/app/(admin)/members/utils/csv.ts`

  - New member CSV download helper.
  - Reuses shared CSV conversion from tree CSV utilities.
  - Names exports with local timestamp.

  ## Admin Trees

  ### `src/app/(admin)/trees/page.tsx`

  - Replaces the old side popout with the new `TreeDetailModal`.
  - Adds working `Add Tree` flow.
  - Adds modal-based row editing.
  - Adds table refetch after tree save/delete.
  - Keeps CSV export, now based on visible table row models.

  ### `src/app/(admin)/trees/utils/csv.ts`

  - Simplifies CSV helpers.
  - Adds safer CSV escaping for commas, quotes, arrays, and newlines.
  - Removes old fetch-and-download helpers.

  ### `src/app/api/admin/trees/[id]/route.ts`

  - Adds explicit admin auth checks for `PUT` and `DELETE`.
  - On tree delete, removes the deleted tree’s ECOSLO number from any member
  `trees_assigned` arrays and updates `trees_count`.

  ### `src/components/TreePageTableWidget.tsx`

  - Adds external `refetchRef` support so parent pages/modals can refresh table
  data without remounting.

  ### `src/components/ControlPanel.tsx`

  - Adds `tableVersion` plumbing.
  - Improves column visibility count syncing.

  ### `src/components/data-table/table-widget-defs.tsx`

  - Changes `survey_logs` display from raw array text to a muted badge.
  - Disables search on `survey_logs`.

  ## Admin Members

  ### `src/app/(admin)/members/page.tsx`

  - Adds `Export CSV`.
  - Replaces key-based table remount refresh with `refetchRef`.
  - Keeps `Add Member` and row-edit modal behavior.

  ### `src/components/MemberPageTableWidget.tsx`

  - Adds external `refetchRef`.
  - Fixes member load error text.

  ### `src/app/api/admin/members/route.ts`

  - On member creation, syncs initial `trees_assigned` values to tree keeper
  assignments.

  ### `src/app/api/admin/members/[id]/route.ts`

  - On member update, detects `trees_assigned` changes and syncs related tree
  keeper state.
  - Uses service-role updates for member row persistence after admin gating.

  ### `src/lib/admin/members.ts`

  - Adds `syncTreeAssignments`.
  - Sets `trees.tree_keeper_id` for newly assigned trees.
  - Clears `tree_keeper_id` for removed trees.
  - Removes transferred trees from other members and updates their
  `trees_count`.

  ### `src/components/assigned-tree-picker-modal.tsx`

  - Shows current keeper names for trees assigned to someone else.
  - Adds transfer confirmation before reassigning another member’s tree.
  - Passes current member id to distinguish own assignments from another
  member’s.

  ### `src/components/volunteer-page-form.tsx`

  - Wires current member id into tree picker.
  - Small UI polish around delete styling, section spacing, and role badge/
  header layout.

  ## Public Map

  ### `src/components/MapClient.tsx`

  - Adjusts selected marker styling.
  - Changes map filter panel width to fit content.

  ### `src/components/MapControlPanel.tsx`

  - Prevents filter pills from wrapping.
  - Renames status filter label from `Off-boarded` to `Graduated`.

  ### `src/components/MapPopout.tsx`

  - Stops converting `Graduated` into `Off-boarded`; displays raw status.

  ## Reminders

  ### `src/components/reminders/ReminderView.tsx`

  - Adds delete confirmation modal for reminders.
  - Keeps delete errors inside confirmation flow.
  - Tweaks layout widths for dropdown/multiselect controls.

  ### `src/components/reminders/RemindersList.tsx`

  - Minor scroll container styling change.

  ## Navigation and Login Polish

  ### `src/components/navbar/SideNavbar.tsx`

  - Changes Tasks icon from chart to checklist.
  - Changes Map icon to map pin in feature nav.
  - Adds login/logout icons in bottom action.
  - Updates logged-in bottom button to render icon plus `Logout`.

  ### `src/components/LogoutButton.tsx`

  - Default label changed from `Log out` to `Logout`.

  ### `src/app/(public)/login/page.tsx`

  - Muted email label styling.
  - Centers the `Back to Public Map` ghost button more explicitly.
