### PR TITLE
fix maps report feature

### DIFF
--- a/src/app/(admin)/trees/page.tsx
+++ b/src/app/(admin)/trees/page.tsx
@@ -17,11 +17,9 @@ export default function Trees() {
   const refetchRef = useRef<(() => void) | null>(null);
   const [treeModalOpen, setTreeModalOpen] = useState(false);
   const [modalTree, setModalTree] = useState<TreeSchema | null>(null);
-  const [tableVersion, setTableVersion] = useState(0);
 
   const handleTableReady = useCallback((table: Table<TreeSchema>) => {
     tableRef.current = table;
-    setTableVersion((v) => v + 1);
   }, []);
 
   const handleAddTreeClick = () => {
@@ -70,7 +68,7 @@ export default function Trees() {
         </>
       }
     >
-      <ControlPanel tableRef={tableRef} tableVersion={tableVersion} />
+      <ControlPanel tableRef={tableRef} />
       <TreePageTableWidget
         refetchRef={refetchRef}
         onRowClick={(event, tree) => {

--- a/src/app/api/public/issue-reports/route.ts
+++ b/src/app/api/public/issue-reports/route.ts
@@ -1,0 +1,160 @@
+import { isEmail, isPhone, postgrestErrorToHttpStatus } from "@/database/utils";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const MAX_MESSAGE_LENGTH = 2000;
+const MAX_CONTACT_LENGTH = 160;
+const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+const RATE_LIMIT_MAX_REQUESTS = 5;
+const SOURCE_TAG = "public_issue_report";
+
+const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
+
+type IssueReportBody = {
+  message?: unknown;
+  reporterEmail?: unknown;
+  reporterName?: unknown;
+  reporterPhone?: unknown;
+  treeId?: unknown;
+};
+
+function cleanOptionalText(value: unknown, maxLength: number) {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, maxLength);
+}
+
+function getClientIp(request: NextRequest) {
+  const forwardedFor = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const realIp = request.headers.get("x-real-ip")?.trim();
+
+  return forwardedFor || realIp || "unknown";
+}
+
+function checkRateLimit(clientIp: string) {
+  const now = Date.now();
+  const bucket = rateLimitBuckets.get(clientIp);
+
+  if (!bucket || bucket.resetAt <= now) {
+    rateLimitBuckets.set(clientIp, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+
+  if (bucket.count >= RATE_LIMIT_MAX_REQUESTS) {
+    return { allowed: false, retryAfterSeconds: Math.ceil((bucket.resetAt - now) / 1000) };
+  }
+
+  bucket.count += 1;
+  return { allowed: true, retryAfterSeconds: 0 };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const rateLimit = checkRateLimit(getClientIp(request));
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { message: "Too many issue reports. Please try again later." },
+        {
+          status: 429,
+          headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
+        },
+      );
+    }
+
+    let body: IssueReportBody;
+    try {
+      body = (await request.json()) as IssueReportBody;
+    } catch {
+      return NextResponse.json({ message: "Invalid JSON body." }, { status: 400 });
+    }
+
+    const treeId = Number(body.treeId);
+    const message = cleanOptionalText(body.message, MAX_MESSAGE_LENGTH);
+    const reporterName = cleanOptionalText(body.reporterName, MAX_CONTACT_LENGTH);
+    const reporterPhone = cleanOptionalText(body.reporterPhone, MAX_CONTACT_LENGTH);
+    const reporterEmail = cleanOptionalText(body.reporterEmail, MAX_CONTACT_LENGTH);
+
+    if (!Number.isInteger(treeId) || treeId <= 0) {
+      return NextResponse.json({ message: "A valid tree is required." }, { status: 400 });
+    }
+
+    if (!message) {
+      return NextResponse.json({ message: "Please enter a report message." }, { status: 400 });
+    }
+
+    if (reporterEmail && !isEmail(reporterEmail)) {
+      return NextResponse.json({ message: "Please enter a valid email address." }, { status: 400 });
+    }
+
+    if (reporterPhone && !isPhone(reporterPhone)) {
+      return NextResponse.json({ message: "Please enter a valid phone number." }, { status: 400 });
+    }
+
+    const supabase = await createServiceRoleClient();
+
+    const { data: tree, error: treeError } = await supabase
+      .from("public_trees")
+      .select("id, ecoslo_num, common_name, address")
+      .eq("id", treeId)
+      .eq("is_public", true)
+      .maybeSingle();
+
+    if (treeError) {
+      console.error("[issue-reports] tree lookup failed:", treeError);
+      return NextResponse.json({ message: treeError.message }, { status: postgrestErrorToHttpStatus(treeError) });
+    }
+
+    if (!tree) {
+      return NextResponse.json({ message: "Tree not found or is not public." }, { status: 404 });
+    }
+
+    const { data: admins, error: adminsError } = await supabase
+      .from("members")
+      .select("id")
+      .eq("role", "Admin")
+      .order("id", { ascending: true });
+
+    if (adminsError) {
+      console.error("[issue-reports] admin lookup failed:", adminsError);
+      return NextResponse.json({ message: adminsError.message }, { status: postgrestErrorToHttpStatus(adminsError) });
+    }
+
+    const adminIds = (admins ?? []).map((admin) => admin.id);
+    const reporterDetails = [reporterName, reporterPhone, reporterEmail].filter(Boolean);
+
+    const reportMessage = [
+      `Source: ${SOURCE_TAG}`,
+      message,
+      `Tree: #${tree.ecoslo_num} (${tree.common_name ?? "Unknown tree"})`,
+      tree.address ? `Address: ${tree.address}` : "",
+      reporterDetails.length > 0 ? `Reported by: ${reporterDetails.join(" ")}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+
+    const { data: task, error: insertError } = await supabase
+      .from("tasks")
+      .insert({
+        assignees: adminIds,
+        completion_date: null,
+        created_by: null,
+        is_complete: false,
+        message: reportMessage,
+        surveys_needed: 0,
+        title: `[${SOURCE_TAG}] Reported Issue on Tree #${tree.ecoslo_num}`,
+      })
+      .select("id")
+      .single();
+
+    if (insertError) {
+      console.error("[issue-reports] task insert failed:", insertError);
+      return NextResponse.json({ message: insertError.message }, { status: postgrestErrorToHttpStatus(insertError) });
+    }
+
+    return NextResponse.json({ message: task }, { status: 201 });
+  } catch (error) {
+    console.error("[issue-reports] unexpected error:", error);
+    return NextResponse.json({ message: "Unexpected server error." }, { status: 500 });
+  }
+}

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type MutableRefObject, type ReactNode, useEffect, useRef, useState } from "react";
+import { type MutableRefObject, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { TreeSchema } from "./data-table/table-widget-defs";
 import { Table } from "./data-table/table/table-types";
 import { Check, ChevronDown, X, type LucideIcon } from "lucide-react";
@@ -33,23 +33,20 @@ interface ControlSearchProps {
 }
 
 export function ControlSearch(props: ControlSearchProps) {
+  const { onQueryChange, placeholder, query, searchDelay, searchFunction } = props;
+
   useEffect(() => {
     const handler = setTimeout(() => {
-      props.searchFunction(props.query);
-    }, props.searchDelay);
+      searchFunction(query);
+    }, searchDelay);
 
     return () => {
       clearTimeout(handler);
     };
-  }, [props.query, props.searchDelay, props.searchFunction, props]);
+  }, [query, searchDelay, searchFunction]);
 
   return (
-    <SearchField
-      id="query"
-      placeholder={props.placeholder || "Search..."}
-      value={props.query}
-      onQueryChange={props.onQueryChange}
-    />
+    <SearchField id="query" placeholder={placeholder || "Search..."} value={query} onQueryChange={onQueryChange} />
   );
 }
 
@@ -189,7 +186,6 @@ interface SelectProps {
   tableRef: MutableRefObject<Table<TreeSchema> | null>;
   onCheckedItem: (item: string) => void;
   triggerClassName?: string;
-  tableVersion?: number;
 }
 
 type SelectItem = {
@@ -274,10 +270,9 @@ function Select(props: SelectProps) {
 
 interface ControlPanelProps {
   tableRef: MutableRefObject<Table<TreeSchema> | null>;
-  tableVersion?: number;
 }
 
-export default function ControlPanel({ tableRef, tableVersion }: ControlPanelProps) {
+export default function ControlPanel({ tableRef }: ControlPanelProps) {
   void tableRef;
 
   const CONTROL_STATUS_OPTIONS = ["All", "Active", "Graduated"];
@@ -288,6 +283,35 @@ export default function ControlPanel({ tableRef, tableVersion }: ControlPanelPro
   const [statusActiveIndex, setStatusActiveIndex] = useState(0);
   const [conditionActiveIndex, setConditionActiveIndex] = useState(0);
   const [visibilityActiveIndex, setVisibilityActiveIndex] = useState(0);
+
+  const searchTrees = useCallback(
+    (query: string) => {
+      const trimmedQuery = query.trimStart();
+      tableRef.current?.setSearchQuery(trimmedQuery);
+    },
+    [tableRef],
+  );
+
+  const filterByStatus = useCallback(
+    (status: string) => {
+      tableRef.current?.setColumnFilter("status", () => (status === "All" ? [] : [status.toLowerCase()]));
+    },
+    [tableRef],
+  );
+
+  const filterByCondition = useCallback(
+    (status: string) => {
+      tableRef.current?.setColumnFilter("condition", () => (status === "All" ? [] : [status.toLowerCase()]));
+    },
+    [tableRef],
+  );
+
+  const filterByVisibility = useCallback(
+    (status: string) => {
+      tableRef.current?.setColumnFilter("is_public", () => (status === "All" ? [] : [status.toLowerCase()]));
+    },
+    [tableRef],
+  );
 
   const resetFilters = () => {
     setSearchQuery("");
@@ -309,10 +333,7 @@ export default function ControlPanel({ tableRef, tableVersion }: ControlPanelPro
             query={searchQuery}
             onQueryChange={setSearchQuery}
             searchDelay={QUERY_DELAY}
-            searchFunction={(query: string) => {
-              const trimmedQuery = query.trimStart();
-              tableRef.current?.setSearchQuery(trimmedQuery);
-            }}
+            searchFunction={searchTrees}
           />
         </div>
         <ControlStatusPills
@@ -323,9 +344,7 @@ export default function ControlPanel({ tableRef, tableVersion }: ControlPanelPro
           activeIndex={statusActiveIndex}
           onActiveIndexChange={setStatusActiveIndex}
           delay={QUERY_DELAY}
-          delayFunction={(status: string) =>
-            tableRef.current?.setColumnFilter("status", () => (status === "All" ? [] : [status.toLowerCase()]))
-          }
+          delayFunction={filterByStatus}
         />
       </div>
 
@@ -338,9 +357,7 @@ export default function ControlPanel({ tableRef, tableVersion }: ControlPanelPro
             activeIndex={conditionActiveIndex}
             onActiveIndexChange={setConditionActiveIndex}
             delay={QUERY_DELAY}
-            delayFunction={(status: string) =>
-              tableRef.current?.setColumnFilter("condition", () => (status === "All" ? [] : [status.toLowerCase()]))
-            }
+            delayFunction={filterByCondition}
           />
           <ControlFilterDropdown
             triggerClassName="w-full"
@@ -349,14 +366,11 @@ export default function ControlPanel({ tableRef, tableVersion }: ControlPanelPro
             activeIndex={visibilityActiveIndex}
             onActiveIndexChange={setVisibilityActiveIndex}
             delay={QUERY_DELAY}
-            delayFunction={(status: string) =>
-              tableRef.current?.setColumnFilter("is_public", () => (status === "All" ? [] : [status.toLowerCase()]))
-            }
+            delayFunction={filterByVisibility}
           />
           <Select
             label="Columns"
             tableRef={tableRef}
-            tableVersion={tableVersion}
             triggerClassName="w-full"
             checkedIcon={<Check />}
             onCheckedItem={(item: string) => tableRef.current?.setColumnVisibility(item, (visible) => !visible)}

--- a/src/components/MapPopout.tsx
+++ b/src/components/MapPopout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Flag, X } from "lucide-react";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useState } from "react";
 import { AppButton, TextField, TextAreaField, controlLabelClassName } from "@/components/ui/form-controls";
 import Badge from "@/components/badge";
 
@@ -23,11 +23,6 @@ type Tree = {
   date_planted: string;
   notes: string;
   is_public: boolean;
-};
-
-type AdminMember = {
-  id: number;
-  role: string | null;
 };
 
 type MapPopoutProps = {
@@ -61,30 +56,6 @@ export default function MapPopout({ tree, onClose }: MapPopoutProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitSuccess, setSubmitSuccess] = useState<string | null>(null);
-  const [adminAssigneeIds, setAdminAssigneeIds] = useState<number[]>([]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    async function loadAdmins() {
-      try {
-        const response = await fetch("/api/admin/members", { cache: "no-store" });
-        if (!response.ok) return;
-        const json = await response.json();
-        const members: AdminMember[] = Array.isArray(json.message) ? json.message : [];
-        if (cancelled) return;
-        const adminIds = members.filter((member) => member.role === "Admin").map((member) => member.id);
-        setAdminAssigneeIds(adminIds);
-      } catch (error) {
-        console.error("Unable to load admin members for issue report", error);
-      }
-    }
-
-    void loadAdmins();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   const clearReportForm = () => {
     setMessage("");
@@ -116,26 +87,19 @@ export default function MapPopout({ tree, onClose }: MapPopoutProps) {
     setSubmitError(null);
     setSubmitSuccess(null);
 
-    const reporterDetails = [reporterName.trim(), reporterPhone.trim(), reporterEmail.trim()].filter(Boolean).join(" ");
-    const bodyMessage = `${message.trim()}${reporterDetails ? `\n\nReported by: ${reporterDetails}` : ""}`;
-
-    const taskPayload = {
-      assignees: adminAssigneeIds.length > 0 ? adminAssigneeIds : [],
-      completion_date: null,
-      created_by: null,
-      is_complete: false,
-      message: bodyMessage,
-      surveys_needed: 0,
-      title: `Reported Issue on Tree ${tree?.id ?? "?"}`,
-    };
-
     try {
-      const response = await fetch("/api/admin/tasks", {
+      const response = await fetch("/api/public/issue-reports", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(taskPayload),
+        body: JSON.stringify({
+          message,
+          reporterEmail,
+          reporterName,
+          reporterPhone,
+          treeId: tree?.id,
+        }),
       });
 
       if (!response.ok) {
@@ -196,7 +160,13 @@ export default function MapPopout({ tree, onClose }: MapPopoutProps) {
       </div>
 
       <div className="mt-7 border-t border-border pt-6">
-        <AppButton type="button" className="mb-3 w-full" icon={Flag} onClick={openReportModal}>
+        <AppButton
+          type="button"
+          className="mb-3 w-full"
+          icon={Flag}
+          onClick={openReportModal}
+          disabled={!tree.is_public}
+        >
           Report an Issue
         </AppButton>
         <AppButton type="button" onClick={onClose} className="w-full" variant="secondary">


### PR DESCRIPTION
## Developer: Matthew Blam

## Summary

  - Fixes the Trees page render loop that caused “Maximum update depth exceeded” errors.
  - Adds a public issue-report endpoint for map reports.
  - Updates the map report form to use the new public endpoint instead of admin-only task APIs.
  - Hardens issue reporting with rate limiting, contact validation, public-tree checks, and source tagging.

  ## Changes

  - Removed the `tableVersion` state update loop from the Trees page.
  - Stabilized tree table search/filter callbacks in `ControlPanel`.
  - Added `POST /api/public/issue-reports`.
  - Creates issue-report tasks server-side with service-role permissions.
  - Assigns generated issue-report tasks to Admin members.
  - Rejects reports for non-public trees.
  - Disables the “Report an Issue” button for non-public trees.
  - Validates optional reporter email and phone fields.
  - Adds basic IP rate limiting: 5 reports per 10 minutes.
  - Tags generated tasks with `[public_issue_report]`.

  ## Verification

  - Ran `npx tsc --noEmit`.
  - Ran `npm run build`.
  - Verified public issue-report task creation.
  - Verified invalid email returns `400`.
  - Verified non-public tree reports return `404`.
  - Removed test task created during verification.