### PR TITLE
Implements Tree Watering/Mulching Status Flow

### DIFF
--- a/src/app/api/public/surveys/route.ts
+++ b/src/app/api/public/surveys/route.ts
@@ -7,6 +7,10 @@ export const dynamic = "force-dynamic";
 
 type SurveyInsert = Pick<TablesInsert<"surveys">, "task" | "tree" | "body">;
 
+// Task types whose completion is driven per-tree and therefore require a
+// survey to name the specific tree that was serviced.
+const TREE_TASK_TYPES = ["Watering", "Mulching"] as const;
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -42,9 +46,50 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: "body must be a JSON object" }, { status: 400 });
     }
 
+    const treeNum: number | null = typeof tree === "number" ? tree : null;
+
+    // Load the task to enforce type-specific rules. RLS limits this to the
+    // caller's own tasks (admins see all); a hidden or missing task falls
+    // through to the insert below, whose RLS policy is the authoritative gate.
+    const { data: taskRow } = await supabase
+      .from("tasks")
+      .select("id, type, is_complete, tree_targets")
+      .eq("id", task)
+      .maybeSingle();
+
+    if (taskRow && (TREE_TASK_TYPES as readonly string[]).includes(taskRow.type)) {
+      if (taskRow.is_complete) {
+        return NextResponse.json({ message: "This task is already complete." }, { status: 409 });
+      }
+      if (treeNum == null) {
+        return NextResponse.json({ message: "Select the tree you serviced to complete this task." }, { status: 400 });
+      }
+
+      // The chosen tree must be one of the task's snapshotted target trees.
+      const targets = taskRow.tree_targets ?? [];
+      if (!targets.includes(treeNum)) {
+        return NextResponse.json({ message: "That tree is not part of this task." }, { status: 400 });
+      }
+
+      // One survey per tree: reject a repeat submission for the same tree.
+      const { data: existing } = await supabase
+        .from("surveys")
+        .select("id")
+        .eq("task", task)
+        .eq("tree", treeNum)
+        .limit(1);
+
+      if (existing && existing.length > 0) {
+        return NextResponse.json(
+          { message: "You have already submitted a survey for this tree on this task." },
+          { status: 409 },
+        );
+      }
+    }
+
     const insert: SurveyInsert = {
       task,
-      tree: tree ?? null,
+      tree: treeNum,
       body: payloadBody as Json,
     };
 
@@ -55,11 +100,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: error.message }, { status: postgrestErrorToHttpStatus(error) });
     }
 
-    if (task) {
-      const { error: rpcError } = await supabase.rpc("complete_task_survey", { p_task_id: task });
-      if (rpcError) {
-        console.error("complete_task_survey RPC failed:", rpcError.message);
-      }
+    // Advance task completion + tree status. The RPC re-validates ownership
+    // and authorization, so it is the final gate regardless of the checks above.
+    const { error: rpcError } = await supabase.rpc("complete_task_survey", {
+      p_task_id: task,
+      p_tree: treeNum ?? undefined,
+    });
+    if (rpcError) {
+      console.error("complete_task_survey RPC failed:", rpcError.message);
     }
 
     return NextResponse.json({ message: data }, { status: 201 });

--- a/src/app/api/public/tasks/[id]/survey-progress/route.ts
+++ b/src/app/api/public/tasks/[id]/survey-progress/route.ts
@@ -1,0 +1,88 @@
+import { createServerLevelClient } from "@/lib/supabase/server";
+import { postgrestErrorToHttpStatus } from "@/database/utils";
+import { NextRequest, NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+type IParams = { params: Promise<{ id: string }> };
+
+type ProgressTree = { ecoslo_num: number; label: string; surveyed: boolean };
+
+function treeLabel(ecoslo_num: number, common_name: string | null, species_name: string | null): string {
+  const primary = common_name?.trim() || species_name?.trim() || "Tree";
+  return `#${ecoslo_num} — ${primary}`;
+}
+
+/**
+ * GET — per-tree survey progress for a Watering/Mulching task.
+ *
+ * Reads the task's frozen `tree_targets` snapshot, cross-references the surveys
+ * already submitted for the task, and returns the checklist the survey form
+ * renders. RLS scopes this to the caller's own tasks (admins see all); the
+ * computation runs server-side so it is correct for admins too (who otherwise
+ * would not have the assignee's trees via tree-keeper RLS).
+ */
+export async function GET(_req: NextRequest, { params }: IParams) {
+  try {
+    const { id } = await params;
+    const taskId = Number(id);
+    if (!Number.isFinite(taskId)) {
+      return NextResponse.json({ message: "Invalid task id" }, { status: 400 });
+    }
+
+    const supabase = await createServerLevelClient();
+
+    const { data: task, error: taskError } = await supabase
+      .from("tasks")
+      .select("id, type, tree_targets")
+      .eq("id", taskId)
+      .maybeSingle();
+
+    if (taskError) {
+      return NextResponse.json({ message: taskError.message }, { status: postgrestErrorToHttpStatus(taskError) });
+    }
+    if (!task) {
+      return NextResponse.json({ message: "Task not found" }, { status: 404 });
+    }
+
+    const targets: number[] = task.tree_targets ?? [];
+
+    // Trees already surveyed for this task.
+    const { data: surveyed } = await supabase.from("surveys").select("tree").eq("task", taskId).not("tree", "is", null);
+
+    const surveyedSet = new Set<number>(
+      (surveyed ?? []).map((s) => s.tree).filter((t): t is number => typeof t === "number"),
+    );
+
+    // Tree display metadata. RLS may hide a target reassigned away from a
+    // keeper; those fall back to the bare "#<num>" label.
+    const meta = new Map<number, { common_name: string | null; species_name: string | null }>();
+    if (targets.length > 0) {
+      const { data: treeRows } = await supabase
+        .from("trees")
+        .select("ecoslo_num, common_name, species_name")
+        .in("ecoslo_num", targets);
+      for (const r of treeRows ?? []) {
+        meta.set(r.ecoslo_num, { common_name: r.common_name, species_name: r.species_name });
+      }
+    }
+
+    const trees: ProgressTree[] = [...targets]
+      .sort((a, b) => a - b)
+      .map((ecoslo_num) => {
+        const m = meta.get(ecoslo_num);
+        return {
+          ecoslo_num,
+          label: m ? treeLabel(ecoslo_num, m.common_name, m.species_name) : `#${ecoslo_num}`,
+          surveyed: surveyedSet.has(ecoslo_num),
+        };
+      });
+
+    const completed = trees.filter((t) => t.surveyed).length;
+
+    return NextResponse.json({ message: { total: trees.length, completed, trees } }, { status: 200 });
+  } catch (e) {
+    console.error("Unexpected error in /api/public/tasks/[id]/survey-progress GET", e);
+    return NextResponse.json({ message: "Unexpected server error" }, { status: 500 });
+  }
+}

--- a/src/components/TaskDetailModal.tsx
+++ b/src/components/TaskDetailModal.tsx
@@ -300,7 +300,12 @@ function TaskDetailModalContent({ task, onOpenChange, onSaved, isAdmin }: Omit<T
         {showSurvey && !isAddingTask ? (
           <ModalDescription className="flex flex-col gap-y-4 py-4 overflow-y-auto max-h-[70vh]">
             <div className="bg-foreground p-6 border border-border rounded-xl">
-              <TaskSurveyForm taskId={task.id} onCompleted={handleSurveyCompleted} />
+              <TaskSurveyForm
+                taskId={task.id}
+                taskType={task.type}
+                onSurveySubmitted={onSaved}
+                onCompleted={handleSurveyCompleted}
+              />
             </div>
           </ModalDescription>
         ) : (

--- a/src/components/reminders/ReminderView.tsx
+++ b/src/components/reminders/ReminderView.tsx
@@ -77,7 +77,10 @@ type ReminderFormState = {
   message: string;
   name: string;
   time: string;
+  /** Template name shown in the "Type" dropdown (display only). */
   type: string;
+  /** Resolved classification persisted to reminders.type. */
+  taskType: Enums<"TaskType">;
 };
 
 export default function ReminderView({
@@ -125,7 +128,10 @@ export default function ReminderView({
     const selectedTemplate = templates.find((template) => template.name === templateName);
 
     if (!selectedTemplate) {
-      updateForm("type", templateName);
+      // No matching template: keep the typed-in label but classify as Other.
+      setForm((current) => ({ ...current, type: templateName, taskType: "Other" }));
+      setSubmitError("");
+      setDeleteError("");
       return;
     }
 
@@ -133,6 +139,7 @@ export default function ReminderView({
       ...current,
       ...getTemplateFormValues(selectedTemplate, members),
       type: selectedTemplate.name,
+      taskType: selectedTemplate.type,
     }));
     setSubmitError("");
     setDeleteError("");
@@ -238,9 +245,9 @@ export default function ReminderView({
           />
         </div>
       )}
-      {!isViewMode && (
-        <div className="flex flex-row gap-4">
-          <div className="flex min-w-0 basis-1/2 text-text-dark">
+      <div className="flex flex-row gap-4">
+        <div className="flex min-w-0 basis-1/2 text-text-dark">
+          {isCreateMode ? (
             <ReminderDropdown
               disabled={isReadOnly}
               label="Type"
@@ -249,7 +256,21 @@ export default function ReminderView({
               value={form.type}
               onOptionClick={handleTemplateSelect}
             />
-          </div>
+          ) : (
+            // Existing reminders don't store which template built them, so the
+            // template picker can't be repopulated. Show the persisted
+            // classification read-only (in both edit and view modes) instead of
+            // a confusing blank dropdown.
+            <ReminderDropdown
+              disabled
+              triggerClassName={viewInputBackgroundClass}
+              label="Type"
+              options={[]}
+              value={form.taskType}
+            />
+          )}
+        </div>
+        {!isViewMode && (
           <div className="flex min-w-0 basis-1/2 text-text-dark">
             <ReminderNestedMultiSelectDropdown
               disabled={isReadOnly}
@@ -260,8 +281,8 @@ export default function ReminderView({
               onChange={(value) => updateForm("assignees", value)}
             />
           </div>
-        </div>
-      )}
+        )}
+      </div>
       <div className="flex flex-col gap-4">
         <div className="flex flex-row gap-4">
           <div className="flex basis-1/2 text-text-dark">
@@ -529,6 +550,9 @@ function getReminderFormState(reminder: Reminder | undefined, members: Member[])
     name: reminder?.name ?? DEFAULT_REMINDER_NAME,
     time: schedule.time,
     type: DEFAULT_REMINDER_TYPE,
+    // Preserve an existing reminder's classification across edits even though
+    // the template ("Type") dropdown starts blank in edit mode.
+    taskType: reminder?.type ?? "Other",
   };
 }
 
@@ -604,11 +628,14 @@ function getReminderPayload(form: ReminderFormState): ReminderInsertPayload {
     assignees,
     crons_expression: crons_expression,
     is_active: form.isActive,
-    is_group_task: assignees.length > 1,
+    // Watering/Mulching are inherently per-keeper; fire_reminder ignores the
+    // group flag for them, but keep it false here so the UI stays consistent.
+    is_group_task: form.taskType === "Other" && assignees.length > 1,
     needs_survey: form.needsSurvey,
     name: form.name.trim(),
     task_message: form.message,
     next_run_at: getNextCronOccurrence(crons_expression).toISOString(),
+    type: form.taskType,
   };
 }
 

--- a/src/components/reminders/ReminderView.tsx
+++ b/src/components/reminders/ReminderView.tsx
@@ -106,6 +106,9 @@ export default function ReminderView({
   const isExistingReminderMode = isEditMode || isViewMode;
   const isReadOnly = isViewMode;
   const viewInputBackgroundClass = isViewMode ? "disabled:!bg-off-white-2" : undefined;
+  // Watering/Mulching are always survey-backed (see surveyRequiredByTaskType);
+  // the Survey toggle is forced on and locked for those types.
+  const surveyRequiredByType = surveyRequiredByTaskType(form.taskType);
   const headerTitle = isExistingReminderMode ? reminder?.name || form.name : "Create New Reminder";
   const headerSubtitle = isExistingReminderMode
     ? assigneeLabel || "No assignees"
@@ -396,11 +399,15 @@ export default function ReminderView({
         </div>
         <div className="basis-1/2">
           <ReminderToggleArea
-            disabled={isReadOnly}
+            disabled={isReadOnly || surveyRequiredByType}
             label="Survey Status"
-            checkedDescription="This reminder requires a survey"
+            checkedDescription={
+              surveyRequiredByType
+                ? "Watering and mulching tasks always require a survey"
+                : "This reminder requires a survey"
+            }
             uncheckedDescription="This reminder does not require a survey"
-            checked={form.needsSurvey}
+            checked={surveyRequiredByType || form.needsSurvey}
             onChange={(value) => updateForm("needsSurvey", value)}
           />
         </div>
@@ -455,6 +462,14 @@ export default function ReminderView({
 
 function isRepeatOption(value: string): value is RepeatOption {
   return (REPEAT_OPTIONS as readonly string[]).includes(value);
+}
+
+// Watering/Mulching tasks are always survey-backed in fire_reminder (one
+// survey per tree), so the reminder form locks the Survey toggle on for them
+// and the payload forces needs_survey true. The flag only affects Other
+// reminders.
+function surveyRequiredByTaskType(taskType: Enums<"TaskType">): boolean {
+  return taskType === "Watering" || taskType === "Mulching";
 }
 
 /**
@@ -530,6 +545,7 @@ function getTemplateFormValues(template: Template, members: Member[]): Partial<R
     dayOfMonth: schedule.dayOfMonth,
     yearlyDate: schedule.yearlyDate,
     message: template.task_message,
+    needsSurvey: template.needs_survey ?? false,
     time: schedule.time,
   };
 }
@@ -631,7 +647,9 @@ function getReminderPayload(form: ReminderFormState): ReminderInsertPayload {
     // Watering/Mulching are inherently per-keeper; fire_reminder ignores the
     // group flag for them, but keep it false here so the UI stays consistent.
     is_group_task: form.taskType === "Other" && assignees.length > 1,
-    needs_survey: form.needsSurvey,
+    // Tree tasks are always survey-backed; persist that rather than the
+    // locked toggle value so the stored reminder matches the UI.
+    needs_survey: surveyRequiredByTaskType(form.taskType) || form.needsSurvey,
     name: form.name.trim(),
     task_message: form.message,
     next_run_at: getNextCronOccurrence(crons_expression).toISOString(),

--- a/src/components/survey/TaskSurveyForm.tsx
+++ b/src/components/survey/TaskSurveyForm.tsx
@@ -7,11 +7,17 @@ import {
   type SurveyIssueValue,
   type SurveyTreeOption,
 } from "@/types/survey";
+import type { Enums } from "@/database/database.types";
 import { useCallback, useEffect, useState } from "react";
 import { AppButton, SelectField, TextField, TextAreaField } from "@/components/ui/form-controls";
+import { CheckCircle2, Circle } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const DEFAULT_ISSUE: SurveyIssueValue = "watering";
+
+/** One target tree on a Watering/Mulching task, with its survey state. */
+type ProgressTree = { ecoslo_num: number; label: string; surveyed: boolean };
+type TaskProgress = { total: number; completed: number; trees: ProgressTree[] };
 
 function isValidOptionalHttpUrl(s: string): boolean {
   const t = s.trim();
@@ -34,11 +40,20 @@ const choiceClass =
 
 interface TaskSurveyFormProps {
   taskId: number;
+  /** Drives per-tree completion: Watering/Mulching tasks require a tree. */
+  taskType?: Enums<"TaskType">;
+  /** Fired after each non-final survey so the parent list can refresh its count. */
+  onSurveySubmitted?: () => void;
   onCompleted: () => void;
 }
 
-export default function TaskSurveyForm({ taskId, onCompleted }: TaskSurveyFormProps) {
+export default function TaskSurveyForm({ taskId, taskType, onSurveySubmitted, onCompleted }: TaskSurveyFormProps) {
+  const requireTree = taskType === "Watering" || taskType === "Mulching";
+
+  // Other tasks: optional tree picked from the full (RLS-scoped) tree list.
   const [trees, setTrees] = useState<SurveyTreeOption[]>([]);
+  // Watering/Mulching tasks: per-tree checklist from the snapshotted targets.
+  const [progress, setProgress] = useState<TaskProgress | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const [treeEcoslo, setTreeEcoslo] = useState("");
@@ -52,17 +67,31 @@ export default function TaskSurveyForm({ taskId, onCompleted }: TaskSurveyFormPr
   const [submitting, setSubmitting] = useState(false);
   const [submitMessage, setSubmitMessage] = useState<{ type: "ok" | "err"; text: string } | null>(null);
 
+  const fetchProgress = useCallback(async (): Promise<TaskProgress | null> => {
+    const res = await fetch(`/api/public/tasks/${taskId}/survey-progress`, { cache: "no-store" });
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(typeof json.message === "string" ? json.message : "Could not load task progress.");
+    }
+    return json.message as TaskProgress;
+  }, [taskId]);
+
   const loadData = useCallback(async () => {
     setLoadError(null);
     try {
-      const result = await fetchPublicTrees();
-      setTrees(result.trees);
-      setLoadError(result.error);
-    } catch {
-      setLoadError("Could not load tree options. Please try again.");
+      if (requireTree) {
+        setProgress(await fetchProgress());
+      } else {
+        const result = await fetchPublicTrees();
+        setTrees(result.trees);
+        setLoadError(result.error);
+      }
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Could not load survey data. Please try again.");
+      setProgress(null);
       setTrees([]);
     }
-  }, []);
+  }, [requireTree, fetchProgress]);
 
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
@@ -70,20 +99,32 @@ export default function TaskSurveyForm({ taskId, onCompleted }: TaskSurveyFormPr
   }, [loadData]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
+  const remainingTrees = progress ? progress.trees.filter((t) => !t.surveyed) : [];
+  const allDone = requireTree && progress != null && progress.total > 0 && progress.completed >= progress.total;
+
+  const treeOptions = requireTree
+    ? remainingTrees.map((t) => ({ label: t.label, value: String(t.ecoslo_num) }))
+    : trees.map((tree) => ({ label: formatTreeLabel(tree), value: String(tree.ecoslo_num) }));
+
+  const clearFieldError = (key: string) => {
+    setFieldErrors((prev) => {
+      if (!prev[key]) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  };
+
   const setIssue = (v: SurveyIssueValue) => {
     setIssueState(v);
-    if (v !== "other") {
-      setFieldErrors((prev) => {
-        if (!prev.issueOther) return prev;
-        const next = { ...prev };
-        delete next.issueOther;
-        return next;
-      });
-    }
+    if (v !== "other") clearFieldError("issueOther");
   };
 
   const validate = (): boolean => {
     const next: Record<string, string> = {};
+    if (requireTree && !treeEcoslo) {
+      next.tree = "Select the tree you serviced.";
+    }
     if (issue === "other" && !issueOther.trim()) {
       next.issueOther = 'Add a description when "Other" is selected.';
     }
@@ -94,34 +135,56 @@ export default function TaskSurveyForm({ taskId, onCompleted }: TaskSurveyFormPr
     return Object.keys(next).length === 0;
   };
 
+  const resetForNextTree = () => {
+    setTreeEcoslo("");
+    setIssueState(DEFAULT_ISSUE);
+    setIssueOther("");
+    setImageLink("");
+    setNotes("");
+    setAdminContact(false);
+    setFieldErrors({});
+  };
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSubmitMessage(null);
     if (!validate()) return;
 
-    const body = buildSurveyBodyPayload({
-      issue,
-      issueOther,
-      imageLink,
-      adminContact,
-      notes,
-    });
-
+    const body = buildSurveyBodyPayload({ issue, issueOther, imageLink, adminContact, notes });
     const treeValue = treeEcoslo ? Number(treeEcoslo) : null;
 
     setSubmitting(true);
     try {
-      const result = await submitSurvey({
-        task: taskId,
-        tree: treeValue,
-        body,
-      });
+      const result = await submitSurvey({ task: taskId, tree: treeValue, body });
       if (!result.ok) {
         setSubmitMessage({ type: "err", text: result.message });
         return;
       }
-      setSubmitMessage({ type: "ok", text: "Survey submitted. Task completed." });
-      setTimeout(onCompleted, 800);
+
+      if (!requireTree) {
+        setSubmitMessage({ type: "ok", text: "Survey submitted." });
+        setTimeout(onCompleted, 800);
+        return;
+      }
+
+      // Watering/Mulching: refresh the checklist and either advance to the
+      // next tree or finish once every target has been surveyed.
+      const next = await fetchProgress().catch(() => null);
+      if (next) setProgress(next);
+
+      if (next && next.total > 0 && next.completed >= next.total) {
+        setSubmitMessage({ type: "ok", text: "All trees surveyed. Task complete." });
+        setTimeout(onCompleted, 800);
+      } else {
+        // Not finished: refresh the list behind the modal so its survey count
+        // stays current even if the member closes before completing every tree.
+        onSurveySubmitted?.();
+        resetForNextTree();
+        setSubmitMessage({
+          type: "ok",
+          text: next ? `Survey submitted — ${next.completed} of ${next.total} trees done.` : "Survey submitted.",
+        });
+      }
     } catch {
       setSubmitMessage({ type: "err", text: "Could not submit. Check your connection and try again." });
     } finally {
@@ -146,123 +209,162 @@ export default function TaskSurveyForm({ taskId, onCompleted }: TaskSurveyFormPr
         </div>
       ) : null}
 
-      {/* Tree */}
-      <div className="flex flex-col items-start gap-y-1">
-        <p className="text-text-muted font-semibold">Tree (optional)</p>
-        <SelectField
-          value={treeEcoslo}
-          onChange={setTreeEcoslo}
-          disabled={submitting}
-          placeholder="Select a tree..."
-          className="bg-button-muted"
-          options={trees.map((tree) => ({ label: formatTreeLabel(tree), value: String(tree.ecoslo_num) }))}
-        />
-      </div>
-
-      {/* Issue */}
-      <div className="flex flex-col items-start gap-y-1">
-        <p className="text-text-muted font-semibold">
-          <span>Issue Type</span>
-          <span className="text-destructive font-semibold"> *</span>
-        </p>
-        <SelectField
-          value={issue}
-          onChange={(value) => setIssue(value as SurveyIssueValue)}
-          disabled={submitting}
-          required
-          className="bg-button-muted"
-          options={SURVEY_ISSUE_OPTIONS.map((option) => ({ label: option.label, value: option.value }))}
-        />
-      </div>
-
-      {issue === "other" ? (
-        <div className="flex flex-col items-start gap-y-1">
+      {/* Per-tree checklist (Watering/Mulching only) */}
+      {requireTree && progress ? (
+        <div className="flex flex-col gap-2 rounded-xl border border-border bg-off-white px-4 py-3">
           <p className="text-text-muted font-semibold">
-            <span>Describe (other)</span>
-            <span className="text-destructive font-semibold"> *</span>
+            {progress.completed} of {progress.total} trees surveyed
           </p>
-          <TextAreaField
-            value={issueOther}
-            onChange={(e) => setIssueOther(e.target.value)}
-            disabled={submitting}
-            placeholder="Describe the issue…"
-            required
-            rows={3}
-            className={cn("bg-button-muted", fieldErrors.issueOther && "border-danger")}
-          />
-          {fieldErrors.issueOther ? <p className="text-sm text-danger">{fieldErrors.issueOther}</p> : null}
+          <ul className="flex flex-col gap-1.5">
+            {progress.trees.map((tree) => (
+              <li key={tree.ecoslo_num} className="flex items-center gap-2 text-sm">
+                {tree.surveyed ? (
+                  <CheckCircle2 className="h-4 w-4 shrink-0 text-success" />
+                ) : (
+                  <Circle className="h-4 w-4 shrink-0 text-text-muted" />
+                )}
+                <span className={cn("text-text-dark", tree.surveyed && "text-text-muted line-through")}>
+                  {tree.label}
+                </span>
+              </li>
+            ))}
+          </ul>
         </div>
       ) : null}
 
-      {/* Image Link */}
-      <div className="flex flex-col items-start gap-y-1">
-        <p className="text-text-muted font-semibold">Image Link (optional)</p>
-        <TextField
-          type="url"
-          inputMode="url"
-          autoComplete="off"
-          value={imageLink}
-          onChange={(e) => setImageLink(e.target.value)}
-          disabled={submitting}
-          placeholder="https://…"
-          className={cn("bg-button-muted", fieldErrors.imageLink && "border-danger")}
-        />
-        {fieldErrors.imageLink ? <p className="text-sm text-danger">{fieldErrors.imageLink}</p> : null}
-      </div>
-
-      {/* Notes */}
-      <div className="flex flex-col items-start gap-y-1">
-        <p className="text-text-muted font-semibold">Notes (optional)</p>
-        <TextAreaField
-          rows={3}
-          className="bg-button-muted"
-          value={notes}
-          onChange={(e) => setNotes(e.target.value)}
-          disabled={submitting}
-          placeholder="Anything else we should know…"
-        />
-      </div>
-
-      {/* Admin Contact */}
-      <div className="flex flex-col items-start gap-y-1">
-        <p className="text-text-muted font-semibold">May an administrator contact you?</p>
-        <div className="flex gap-3">
-          <label className={choiceClass}>
-            <input
-              type="radio"
-              name="survey-admin-contact"
-              className="h-4 w-4 accent-primary"
-              checked={adminContact === true}
-              onChange={() => setAdminContact(true)}
+      {allDone ? (
+        <p className={cn("text-sm font-medium", submitMessage?.type === "err" ? "text-danger" : "text-success")}>
+          {submitMessage?.text ?? "All trees have been surveyed for this task."}
+        </p>
+      ) : (
+        <>
+          {/* Tree */}
+          <div className="flex flex-col items-start gap-y-1">
+            <p className="text-text-muted font-semibold">
+              <span>{requireTree ? "Tree" : "Tree (optional)"}</span>
+              {requireTree ? <span className="text-destructive font-semibold"> *</span> : null}
+            </p>
+            <SelectField
+              value={treeEcoslo}
+              onChange={(value) => {
+                setTreeEcoslo(value);
+                clearFieldError("tree");
+              }}
               disabled={submitting}
+              required={requireTree}
+              placeholder="Select a tree..."
+              className={cn("bg-button-muted", fieldErrors.tree && "border-danger")}
+              options={treeOptions}
             />
-            <span className="text-base text-text font-mulish">Yes</span>
-          </label>
-          <label className={choiceClass}>
-            <input
-              type="radio"
-              name="survey-admin-contact"
-              className="h-4 w-4 accent-primary"
-              checked={adminContact === false}
-              onChange={() => setAdminContact(false)}
-              disabled={submitting}
-            />
-            <span className="text-base text-text font-mulish">No</span>
-          </label>
-        </div>
-      </div>
+            {fieldErrors.tree ? <p className="text-sm text-danger">{fieldErrors.tree}</p> : null}
+          </div>
 
-      {/* Submit */}
-      <div className="flex items-center gap-4 pt-2">
-        <AppButton type="submit" disabled={submitting}>
-          {submitting ? "Submitting…" : "Submit Survey"}
-        </AppButton>
-        {submitMessage ? (
-          <p className={submitMessage.type === "ok" ? "text-sm text-success" : "text-sm text-danger"}>
-            {submitMessage.text}
-          </p>
-        ) : null}
-      </div>
+          {/* Issue */}
+          <div className="flex flex-col items-start gap-y-1">
+            <p className="text-text-muted font-semibold">
+              <span>Issue Type</span>
+              <span className="text-destructive font-semibold"> *</span>
+            </p>
+            <SelectField
+              value={issue}
+              onChange={(value) => setIssue(value as SurveyIssueValue)}
+              disabled={submitting}
+              required
+              className="bg-button-muted"
+              options={SURVEY_ISSUE_OPTIONS.map((option) => ({ label: option.label, value: option.value }))}
+            />
+          </div>
+
+          {issue === "other" ? (
+            <div className="flex flex-col items-start gap-y-1">
+              <p className="text-text-muted font-semibold">
+                <span>Describe (other)</span>
+                <span className="text-destructive font-semibold"> *</span>
+              </p>
+              <TextAreaField
+                value={issueOther}
+                onChange={(e) => setIssueOther(e.target.value)}
+                disabled={submitting}
+                placeholder="Describe the issue…"
+                required
+                rows={3}
+                className={cn("bg-button-muted", fieldErrors.issueOther && "border-danger")}
+              />
+              {fieldErrors.issueOther ? <p className="text-sm text-danger">{fieldErrors.issueOther}</p> : null}
+            </div>
+          ) : null}
+
+          {/* Image Link */}
+          <div className="flex flex-col items-start gap-y-1">
+            <p className="text-text-muted font-semibold">Image Link (optional)</p>
+            <TextField
+              type="url"
+              inputMode="url"
+              autoComplete="off"
+              value={imageLink}
+              onChange={(e) => setImageLink(e.target.value)}
+              disabled={submitting}
+              placeholder="https://…"
+              className={cn("bg-button-muted", fieldErrors.imageLink && "border-danger")}
+            />
+            {fieldErrors.imageLink ? <p className="text-sm text-danger">{fieldErrors.imageLink}</p> : null}
+          </div>
+
+          {/* Notes */}
+          <div className="flex flex-col items-start gap-y-1">
+            <p className="text-text-muted font-semibold">Notes (optional)</p>
+            <TextAreaField
+              rows={3}
+              className="bg-button-muted"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              disabled={submitting}
+              placeholder="Anything else we should know…"
+            />
+          </div>
+
+          {/* Admin Contact */}
+          <div className="flex flex-col items-start gap-y-1">
+            <p className="text-text-muted font-semibold">May an administrator contact you?</p>
+            <div className="flex gap-3">
+              <label className={choiceClass}>
+                <input
+                  type="radio"
+                  name="survey-admin-contact"
+                  className="h-4 w-4 accent-primary"
+                  checked={adminContact === true}
+                  onChange={() => setAdminContact(true)}
+                  disabled={submitting}
+                />
+                <span className="text-base text-text font-mulish">Yes</span>
+              </label>
+              <label className={choiceClass}>
+                <input
+                  type="radio"
+                  name="survey-admin-contact"
+                  className="h-4 w-4 accent-primary"
+                  checked={adminContact === false}
+                  onChange={() => setAdminContact(false)}
+                  disabled={submitting}
+                />
+                <span className="text-base text-text font-mulish">No</span>
+              </label>
+            </div>
+          </div>
+
+          {/* Submit */}
+          <div className="flex items-center gap-4 pt-2">
+            <AppButton type="submit" disabled={submitting}>
+              {submitting ? "Submitting…" : "Submit Survey"}
+            </AppButton>
+            {submitMessage ? (
+              <p className={submitMessage.type === "ok" ? "text-sm text-success" : "text-sm text-danger"}>
+                {submitMessage.text}
+              </p>
+            ) : null}
+          </div>
+        </>
+      )}
     </form>
   );
 }

--- a/src/database/database.types.ts
+++ b/src/database/database.types.ts
@@ -225,6 +225,7 @@ export type Database = {
           id: number;
           is_group_task: boolean;
           name: string;
+          needs_survey: boolean;
           task_message: string;
           type: Database["public"]["Enums"]["TaskType"];
         };
@@ -235,6 +236,7 @@ export type Database = {
           id?: number;
           is_group_task?: boolean;
           name?: string;
+          needs_survey?: boolean;
           task_message?: string;
           type?: Database["public"]["Enums"]["TaskType"];
         };
@@ -245,6 +247,7 @@ export type Database = {
           id?: number;
           is_group_task?: boolean;
           name?: string;
+          needs_survey?: boolean;
           task_message?: string;
           type?: Database["public"]["Enums"]["TaskType"];
         };

--- a/src/database/database.types.ts
+++ b/src/database/database.types.ts
@@ -63,6 +63,7 @@ export type Database = {
           needs_survey: boolean;
           next_run_at: string;
           task_message: string;
+          type: Database["public"]["Enums"]["TaskType"];
         };
         Insert: {
           assignees: number[];
@@ -76,6 +77,7 @@ export type Database = {
           needs_survey?: boolean;
           next_run_at: string;
           task_message?: string;
+          type?: Database["public"]["Enums"]["TaskType"];
         };
         Update: {
           assignees?: number[];
@@ -89,6 +91,7 @@ export type Database = {
           needs_survey?: boolean;
           next_run_at?: string;
           task_message?: string;
+          type?: Database["public"]["Enums"]["TaskType"];
         };
         Relationships: [];
       };
@@ -153,6 +156,8 @@ export type Database = {
           reminder_id: number | null;
           surveys_needed: number;
           title: string;
+          tree_targets: number[] | null;
+          type: Database["public"]["Enums"]["TaskType"];
         };
         Insert: {
           assignees?: number[] | null;
@@ -168,6 +173,8 @@ export type Database = {
           reminder_id?: number | null;
           surveys_needed?: number;
           title?: string;
+          tree_targets?: number[] | null;
+          type?: Database["public"]["Enums"]["TaskType"];
         };
         Update: {
           assignees?: number[] | null;
@@ -183,6 +190,8 @@ export type Database = {
           reminder_id?: number | null;
           surveys_needed?: number;
           title?: string;
+          tree_targets?: number[] | null;
+          type?: Database["public"]["Enums"]["TaskType"];
         };
         Relationships: [
           {
@@ -217,6 +226,7 @@ export type Database = {
           is_group_task: boolean;
           name: string;
           task_message: string;
+          type: Database["public"]["Enums"]["TaskType"];
         };
         Insert: {
           assignees: number[];
@@ -226,6 +236,7 @@ export type Database = {
           is_group_task?: boolean;
           name?: string;
           task_message?: string;
+          type?: Database["public"]["Enums"]["TaskType"];
         };
         Update: {
           assignees?: number[];
@@ -235,6 +246,7 @@ export type Database = {
           is_group_task?: boolean;
           name?: string;
           task_message?: string;
+          type?: Database["public"]["Enums"]["TaskType"];
         };
         Relationships: [];
       };
@@ -400,10 +412,21 @@ export type Database = {
       };
     };
     Functions: {
+      complete_task_survey: {
+        Args: { p_task_id: number; p_tree?: number };
+        Returns: undefined;
+      };
       current_member_id: { Args: never; Returns: number };
       fire_reminder: {
         Args: { p_next_run_at: string; p_reminder_id: number };
         Returns: undefined;
+      };
+      fire_reminders_batch: {
+        Args: { p_next_run_ats: string[]; p_reminder_ids: number[] };
+        Returns: {
+          failed: number;
+          fired: number;
+        }[];
       };
       get_pending_email_jobs: {
         Args: { p_limit?: number };
@@ -427,6 +450,7 @@ export type Database = {
       Condition: "good" | "fair" | "poor";
       MemberType: "Admin" | "Tree Keeper";
       MulchingStatus: "Completed" | "Pending";
+      TaskType: "Watering" | "Mulching" | "Other";
       TreeStatus: "Active" | "Graduated";
       WateringStatus: "Completed" | "Pending";
     };
@@ -551,6 +575,7 @@ export const Constants = {
       Condition: ["good", "fair", "poor"],
       MemberType: ["Admin", "Tree Keeper"],
       MulchingStatus: ["Completed", "Pending"],
+      TaskType: ["Watering", "Mulching", "Other"],
       TreeStatus: ["Active", "Graduated"],
       WateringStatus: ["Completed", "Pending"],
     },

--- a/supabase/migrations/20260521000001_cleanup_completed_tasks_cron.sql
+++ b/supabase/migrations/20260521000001_cleanup_completed_tasks_cron.sql
@@ -1,22 +1,33 @@
--- Schedule daily cleanup of completed tasks older than 30 days.
--- Runs at 3:00 AM UTC every day.
+-- =============================================================================
+-- ECOSLO: schedule daily cleanup of completed tasks
+-- =============================================================================
+-- Invokes the cleanup-completed-tasks Edge Function once a day (03:00 UTC) to
+-- delete completed tasks (and their linked surveys) older than 30 days.
 --
--- NOTE: Replace the URL and Authorization bearer token below with
--- the actual SUPABASE_URL and SUPABASE_ANON_KEY for your environment.
+-- Credentials are read from Supabase Vault at run time instead of being
+-- hardcoded, matching the existing tick-reminders / send-pending-emails crons:
+--   * project_url      -> the project's base URL
+--   * service_role_key -> the bearer token. cleanup-completed-tasks performs
+--     RLS-bypassing deletes and is a privileged maintenance endpoint, so it is
+--     authorized with the service role -- NOT the public anon key, which is
+--     shipped to browsers and would let anyone trigger the cleanup.
+--
+-- Both secrets already exist in Vault. cron.schedule upserts by job name, so
+-- re-running this migration is idempotent.
+-- =============================================================================
 
 select cron.schedule(
   'cleanup-completed-tasks',
   '0 3 * * *',
   $$
   select net.http_post(
-    -- TODO: set per-environment: <SUPABASE_URL>/functions/v1/cleanup-completed-tasks
-    url := 'https://YOUR_PROJECT_REF.supabase.co/functions/v1/cleanup-completed-tasks',
+    url := (select decrypted_secret from vault.decrypted_secrets where name = 'project_url')
+           || '/functions/v1/cleanup-completed-tasks',
     headers := jsonb_build_object(
-      'Content-Type', 'application/json',
-      -- TODO: set per-environment: SUPABASE_ANON_KEY
-      'Authorization', 'Bearer YOUR_ANON_KEY'
-    ),
-    body := '{}'::jsonb
+      'Authorization',
+      'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'service_role_key'),
+      'Content-Type', 'application/json'
+    )
   );
   $$
 );

--- a/supabase/migrations/20260529000000_add_task_type.sql
+++ b/supabase/migrations/20260529000000_add_task_type.sql
@@ -1,0 +1,54 @@
+-- =============================================================================
+-- ECOSLO: TaskType classification
+-- =============================================================================
+-- Adds a "TaskType" enum and a `type` column to templates, reminders, and
+-- tasks. The type flows Template -> Reminder -> Task:
+--   * A template declares its kind (Watering / Mulching / Other).
+--   * A reminder created from a template inherits that kind; reminders created
+--     without a template stay 'Other'.
+--   * fire_reminder copies reminders.type onto every task it generates.
+-- Watering/Mulching tasks drive tree status updates on completion (see the
+-- fire_reminder and complete_task_survey migrations).
+--
+-- Also adds tasks.tree_targets: a snapshot of the ecoslo_nums a Watering/
+-- Mulching task covers, captured by fire_reminder at fire time. It is the
+-- authoritative per-task tree list — driving completion (one survey per
+-- target), the survey checklist UX, and the "most recent task for this tree"
+-- recency guard — and is intentionally NOT re-derived if a member's
+-- assignment changes mid-cycle.
+--
+-- Existing rows backfill to 'Other' / NULL via the column defaults, which is
+-- the correct, behavior-preserving state for anything created before typing
+-- existed.
+-- =============================================================================
+
+create type "public"."TaskType" as enum ('Watering', 'Mulching', 'Other');
+
+alter table "public"."templates"
+  add column "type" "public"."TaskType" not null default 'Other';
+
+alter table "public"."reminders"
+  add column "type" "public"."TaskType" not null default 'Other';
+
+alter table "public"."tasks"
+  add column "type" "public"."TaskType" not null default 'Other';
+
+alter table "public"."tasks"
+  add column "tree_targets" bigint[];
+
+-- Accelerates the recency guard's `tree_targets @> array[tree]` containment
+-- check in complete_task_survey.
+create index if not exists "tasks_tree_targets_gin"
+  on "public"."tasks" using gin ("tree_targets");
+
+comment on column "public"."templates"."type" is
+  'Classification of reminders built from this template (Watering/Mulching/Other).';
+
+comment on column "public"."reminders"."type" is
+  'Classification copied from the source template, or Other when none. Propagated to tasks at fire time.';
+
+comment on column "public"."tasks"."type" is
+  'Copied from the parent reminder. Watering/Mulching completions update the related tree status.';
+
+comment on column "public"."tasks"."tree_targets" is
+  'Snapshot (at fire time) of the tree ecoslo_nums a Watering/Mulching task covers. Authoritative per-task tree list; NULL for Other tasks.';

--- a/supabase/migrations/20260529000001_fire_reminder_typed.sql
+++ b/supabase/migrations/20260529000001_fire_reminder_typed.sql
@@ -1,0 +1,120 @@
+-- =============================================================================
+-- ECOSLO: fire_reminder (type-aware)
+-- =============================================================================
+-- Extends the original fire_reminder:
+--   * Every generated task inherits reminders.type.
+--   * Watering/Mulching reminders are ALWAYS per-member (the is_group_task
+--     flag is ignored): one task per assignee, with tree_targets snapshotting
+--     the ecoslo_nums that member currently keeps and surveys_needed set to
+--     that count, so the task only completes once the member has surveyed
+--     every one of those trees. A member who keeps no trees gets no task.
+--   * Firing opens a new cycle for each assignee's trees: status -> Pending
+--     and next_(watering|mulching)_date -> the reminder's next scheduled run.
+--     This is the "next cycle resets to Pending" half of the recency model;
+--     completion (complete_task_survey) flips individual trees to Completed.
+--   * 'Other' reminders keep the original behavior exactly.
+--
+-- create or replace preserves the existing owner and grants (service_role).
+-- =============================================================================
+create or replace function public.fire_reminder(p_reminder_id bigint, p_next_run_at timestamptz)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  r reminders%rowtype;
+  v_assignee bigint;
+  v_surveys_needed integer;
+  v_tree_targets bigint[];
+  v_tree_count integer;
+  -- next_(watering|mulching)_date are DATE columns; anchor them to the PST
+  -- calendar date of the next run, matching the scheduler's PST-aware cron.
+  v_next_date date := (p_next_run_at at time zone 'America/Los_Angeles')::date;
+begin
+  -- Lock the row and re-check it's still due. SKIP LOCKED means a concurrent
+  -- tick already processing this row exits cleanly instead of waiting.
+  -- Re-checking next_run_at <= now() guards against the row being advanced
+  -- between the Edge Function's scan and this call.
+  select * into r
+  from reminders
+  where id = p_reminder_id
+    and is_active = true
+    and next_run_at <= now()
+  for update skip locked;
+
+  if not found then
+    return;
+  end if;
+
+  if r.type in ('Watering', 'Mulching') then
+    -- Per-member: one task per assignee, one survey required per tree kept.
+    foreach v_assignee in array r.assignees loop
+      -- Snapshot the trees this member keeps right now. This list is frozen
+      -- onto the task and is what the survey checklist and completion check
+      -- read; later assignment changes do not affect the in-flight task.
+      select array_agg(ecoslo_num order by ecoslo_num) into v_tree_targets
+      from trees
+      where tree_keeper_id = v_assignee;
+
+      v_tree_count := coalesce(array_length(v_tree_targets, 1), 0);
+
+      -- A member with no assigned trees has nothing to do this cycle.
+      if v_tree_count > 0 then
+        insert into tasks (
+          title, message, assignees, is_complete, completion_date,
+          surveys_needed, reminder_id, type, tree_targets
+        ) values (
+          r.name, r.task_message, array[v_assignee], false, null,
+          v_tree_count, r.id, r.type, v_tree_targets
+        );
+
+        -- Open the new cycle for this keeper's trees.
+        if r.type = 'Watering' then
+          update trees
+          set weekly_watering_status = 'Pending',
+              next_watering_date = v_next_date
+          where tree_keeper_id = v_assignee;
+        else
+          update trees
+          set yearly_mulching_status = 'Pending',
+              next_mulching_date = v_next_date
+          where tree_keeper_id = v_assignee;
+        end if;
+      end if;
+    end loop;
+
+  elsif r.is_group_task then
+    v_surveys_needed := case
+      when r.needs_survey then coalesce(array_length(r.assignees, 1), 0)
+      else 0
+    end;
+    insert into tasks (
+      title, message, assignees, is_complete, completion_date,
+      surveys_needed, reminder_id, type
+    ) values (
+      r.name, r.task_message, r.assignees, false, null,
+      v_surveys_needed, r.id, r.type
+    );
+
+  else
+    v_surveys_needed := case when r.needs_survey then 1 else 0 end;
+    foreach v_assignee in array r.assignees loop
+      insert into tasks (
+        title, message, assignees, is_complete, completion_date,
+        surveys_needed, reminder_id, type
+      ) values (
+        r.name, r.task_message, array[v_assignee], false, null,
+        v_surveys_needed, r.id, r.type
+      );
+    end loop;
+  end if;
+
+  -- Advance the reminder. Everything above + this UPDATE is one transaction;
+  -- if any of it fails, none of it commits and the reminder stays due.
+  update reminders
+  set next_run_at = p_next_run_at,
+      last_run_at = now()
+  where id = p_reminder_id;
+end;
+$$;

--- a/supabase/migrations/20260529000002_complete_task_survey_typed.sql
+++ b/supabase/migrations/20260529000002_complete_task_survey_typed.sql
@@ -1,0 +1,122 @@
+-- =============================================================================
+-- ECOSLO: complete_task_survey (type-aware, tree-status driving)
+-- =============================================================================
+-- Survey submission calls this after inserting the survey row. It now:
+--   * Authorizes the caller: only the task's assignees or an admin may
+--     advance it. This both protects the generic decrement and stops a direct
+--     SECURITY DEFINER call from flipping trees on someone else's behalf.
+--   * For Watering/Mulching tasks (driven by the task's tree_targets snapshot):
+--       - requires a tree, and that tree must be one of the task's targets;
+--       - counts only the FIRST survey for a given (task, tree) pair toward
+--         completion (distinct-tree enforcement — duplicates are ignored);
+--       - recomputes coverage from the target list: surveys_needed mirrors the
+--         remaining count and the task completes once every target is surveyed;
+--       - marks that tree's weekly_watering_status / yearly_mulching_status
+--         'Completed', but only if no newer task of the same type also targets
+--         the tree (recency guard: a late survey on a stale task is ignored
+--         because a newer cycle's task already exists).
+--   * For 'Other' tasks: unchanged single-decrement behavior.
+--
+-- The added p_tree parameter changes the signature, so the old single-arg
+-- function is dropped first. Execute is restricted to authenticated (the
+-- survey route's role) and service_role.
+-- =============================================================================
+
+drop function if exists public.complete_task_survey(bigint);
+
+create or replace function public.complete_task_survey(
+  p_task_id bigint,
+  p_tree    bigint default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_task     tasks%rowtype;
+  v_total    integer;
+  v_surveyed integer;
+  v_count    integer;
+begin
+  -- Lock the task so concurrent survey submissions for it serialize.
+  select * into v_task
+  from tasks
+  where id = p_task_id
+  for update;
+
+  if not found or v_task.is_complete then
+    return;
+  end if;
+
+  -- Only an assignee or an admin may complete the task.
+  if not (public.is_admin() or public.current_member_id() = any(v_task.assignees)) then
+    return;
+  end if;
+
+  if v_task.type in ('Watering', 'Mulching') then
+    -- Watering/Mulching require one survey per snapshotted target tree. The
+    -- surveyed tree must be one of those targets (the snapshot is authoritative,
+    -- so reassignment after fire time is intentionally not considered).
+    if p_tree is null or v_task.tree_targets is null or not (p_tree = any(v_task.tree_targets)) then
+      return;
+    end if;
+
+    -- A survey for this (task, tree) must actually exist before it counts
+    -- toward coverage or flips the tree — this stops a bare RPC call from
+    -- marking a tree serviced with no survey behind it. Coverage is recomputed
+    -- from DISTINCT surveyed trees below, so a duplicate (a rare concurrent
+    -- double-submit) is harmless and idempotent rather than dropped.
+    select count(*) into v_count
+    from surveys
+    where task = p_task_id and tree = p_tree;
+
+    if v_count < 1 then
+      return;
+    end if;
+
+    -- Recompute coverage from the frozen target list: surveys_needed mirrors
+    -- the remaining count, and the task completes once every target is surveyed.
+    v_total := coalesce(array_length(v_task.tree_targets, 1), 0);
+
+    select count(distinct s.tree) into v_surveyed
+    from surveys s
+    where s.task = p_task_id
+      and s.tree = any(v_task.tree_targets);
+
+    update tasks
+    set surveys_needed = greatest(v_total - v_surveyed, 0),
+        is_complete = (v_total > 0 and v_surveyed >= v_total),
+        completion_date = case when (v_total > 0 and v_surveyed >= v_total) then now() else completion_date end
+    where id = p_task_id;
+
+    -- Mark the tree serviced only if no newer task of the same type also
+    -- targets it (i.e. this is the current cycle's task, not a stale one).
+    if not exists (
+      select 1
+      from tasks t2
+      where t2.type = v_task.type
+        and t2.id <> v_task.id
+        and t2.created_at > v_task.created_at
+        and t2.tree_targets @> array[p_tree]
+    ) then
+      if v_task.type = 'Watering' then
+        update trees set weekly_watering_status = 'Completed' where ecoslo_num = p_tree;
+      else
+        update trees set yearly_mulching_status = 'Completed' where ecoslo_num = p_tree;
+      end if;
+    end if;
+
+  else
+    -- 'Other': original behavior — one decrement per survey.
+    update tasks
+    set surveys_needed = greatest(surveys_needed - 1, 0),
+        is_complete = case when surveys_needed <= 1 then true else is_complete end,
+        completion_date = case when surveys_needed <= 1 then now() else completion_date end
+    where id = p_task_id and not is_complete;
+  end if;
+end;
+$$;
+
+revoke all on function public.complete_task_survey(bigint, bigint) from public;
+grant execute on function public.complete_task_survey(bigint, bigint) to authenticated, service_role;

--- a/supabase/migrations/20260529000003_add_template_needs_survey.sql
+++ b/supabase/migrations/20260529000003_add_template_needs_survey.sql
@@ -1,0 +1,18 @@
+-- =============================================================================
+-- ECOSLO: templates.needs_survey
+-- =============================================================================
+-- Mirrors the existing `type` passthrough: a template now also carries a
+-- needs_survey default that the reminder form copies onto a reminder when the
+-- template is selected. Existing templates backfill to false via the default,
+-- matching reminders.needs_survey.
+--
+-- Note: needs_survey only affects 'Other' reminders. Watering/Mulching tasks
+-- are always survey-backed (one survey per tree) in fire_reminder regardless
+-- of this flag, and the reminder form locks the survey toggle on for them.
+-- =============================================================================
+
+alter table "public"."templates"
+  add column "needs_survey" boolean not null default false;
+
+comment on column "public"."templates"."needs_survey" is
+  'Default survey requirement copied onto reminders created from this template. Ignored for Watering/Mulching (always survey-backed).';


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

Implements the **automated tree-status flow**: when a member completes the watering or mulching task generated by a Reminder, the associated trees' `weekly_watering_status` / `yearly_mulching_status` are updated to `Completed`. To do this cleanly, this PR introduces a **TaskType** classification (`Watering` / `Mulching` / `Other`) that flows from a Template, to the Reminder it builds, to the Tasks that Reminder generates on its schedule.
  
As with our RLS work (#107), the majority of these changes operate on Supabase itself rather than in the app, and are applied programmatically through **migrations** — SQL files in `/supabase/migrations/`, prefixed with a timestamp to enforce a strict, consistent ordering. These are pushed via the Supabase CLI so every schema/RPC change is logged and reproducible rather than clicked through the Supabase UI. The app-side changes (in `/src`) wire the new fields and RPC into the reminder form and the survey flow.

#### 1. TaskType Classification + Tree Snapshot (schema)

_Migration: `20260529000000_add_task_type.sql`_

- Adds a `TaskType` enum (`Watering`, `Mulching`, `Other`) and a `type` column to the **templates**, **reminders**, and **tasks** tables. A template declares its kind; a reminder built from a template inherits it; `fire_reminder` copies it onto every task it generates. Existing rows backfill to `Other`, which is behavior-preserving (they keep working exactly as before).
- Adds `tasks.tree_targets` (`bigint[]`): a **snapshot**, taken at the moment the task is created, of the `ecoslo_num`s of the trees the assignee keeps. This is the authoritative per-task tree list — it drives the survey checklist, the completion check, and the "is this the most recent task for this tree" guard. It is intentionally **frozen**: if a member's tree assignment changes mid-cycle, the in-flight task is unaffected. A GIN index supports the containment lookups used later.

#### 2. Task Generation for Tree Tasks (`fire_reminder`)

_Migration: `20260529000001_fire_reminder_typed.sql`_
  
`fire_reminder` is the RPC (invoked each minute by the `tick-reminders` Edge Function via `fire_reminders_batch`) that turns a due Reminder into Tasks. It now branches on `type`:

- **Watering / Mulching:** always **per-member** (the group-task flag is ignored). For each assignee, it snapshots the trees that member currently keeps into `tree_targets`, sets `surveys_needed` to that count, and creates one task — so the task can only be completed once the member has surveyed **every** tree they keep. A member who keeps no trees gets no task. Firing also opens a new cycle for those trees: it sets their status back to `Pending` and updates `next_watering_date` / `next_mulching_date` to the reminder's next scheduled run (anchored to the **America/Los_Angeles** calendar date, matching our PST-aware scheduler).
- **Other:** unchanged — keeps the original group / per-member behavior, with `surveys_needed` still contingent on `needs_survey`.

#### 3. Survey-Driven Tree Status (`complete_task_survey`)

_Migration: `20260529000002_complete_task_survey_typed.sql`_

This RPC runs after a survey is submitted. The signature gains a `p_tree` argument (the old single-arg version is dropped and execute is re-granted to `authenticated` + `service_role`). For **Watering / Mulching** tasks it now:

- **Authorizes the caller** — only the task's assignees or an admin may advance it, so a direct RPC call can't flip someone else's trees.
- **Validates the tree** — the surveyed `p_tree` must be one of the task's `tree_targets`.
- **Counts distinct coverage** — completion is recomputed from the number of *distinct* surveyed target trees, so submitting the same tree twice can't game the counter (the survey route also rejects duplicates up front). The task completes once every target tree has a survey.
- **Marks the tree serviced** — sets `weekly_watering_status` / `yearly_mulching_status` to `Completed`, but only if no **newer** task of the same type also targets that tree (a **recency guard**, so a late survey on a stale task can't overwrite a fresh cycle).

`Other` tasks keep the original one-decrement-per-survey behavior.

#### 4. Survey Requirement Inheritance + Locked Toggle (`templates.needs_survey`)

_Migration: `20260529000003_add_template_needs_survey.sql`_

Previously a Template couldn't carry a survey default, so the Reminder form's "Survey Status" toggle didn't inherit anything on template selection. This adds `templates.needs_survey` (backfilled `false`) and copies it onto the form when a template is picked, mirroring how `type` already flows through.

Importantly, Watering/Mulching tasks are **always survey-backed** (one survey per tree — see §2), so `fire_reminder` ignores `needs_survey` for them. To avoid misleading the client, the reminder form now **disables and force-checks** the Survey toggle for those types ("Watering and mulching tasks always require a survey"), and persists `needs_survey = true` for them so stored data matches the UI. The flag therefore only has an effect for `Other` reminders. If we later want per-task control over watering/mulching surveys, that's a localized future edit.
  
#### 5. Frontend — Multi-Tree Survey Completion

A watering/mulching task covers several trees, so the survey UX is now a **checklist**:

- A new endpoint, `src/app/api/public/tasks/[id]/survey-progress/route.ts`, returns the task's target trees and which have been surveyed.
- `src/components/survey/TaskSurveyForm.tsx` renders the checklist, only offers un-surveyed trees, and stays open until all are done. `Other` tasks keep the original single-submit form.
- `src/app/api/public/surveys/route.ts` validates that the submitted tree belongs to the task's `tree_targets`, rejects duplicate submissions, and then calls the typed `complete_task_survey` RPC, which re-validates everything server-side as the final gate.
- `src/components/TaskDetailModal.tsx` passes the task's type and a refresh callback into the form.

#### 6. Frontend — Reminder Form (Type + Survey Toggle)

`src/components/reminders/ReminderView.tsx` now shows the resolved `TaskType` in all three modes (create shows the template picker; edit/view show it read-only), copies `needs_survey` from the selected template, and applies the locked-toggle behavior from §4.

#### 7. Cleanup Cron — Vault Fix (chore)
  
The previously-merged `20260521000001_cleanup_completed_tasks_cron.sql` shipped with placeholder credentials (`YOUR_PROJECT_REF` / `YOUR_ANON_KEY`). It's rewritten to read `project_url` and `service_role_key` from **Supabase Vault** at run time, matching our existing `tick-reminders` and `send-pending-emails` cron jobs (and using the service-role key, since the cleanup function performs RLS-bypassing deletes and shouldn't be triggerable with the public anon key).

_Credits: the `cleanup-completed-tasks` Edge Function, the original `complete_task_survey`, and the task page these surveys plug into were set up by Matthew in #134 ("task page overhaul"); this PR extends and types that work._

### Testing Considerations
  
To exercise the full flow locally (after this PR is checked out):

1. **Assign trees to a member — through the admin Members UI, not by hand.**  `fire_reminder` looks up a member's trees via `trees.tree_keeper_id`, while RLS/surveys gate on `members.trees_assigned`. The admin Members API keeps these two in sync (`syncTreeAssignments`); editing `trees_assigned` directly in the table editor does **not** set `tree_keeper_id`, so the reminder will fire but generate **no task** (a member with zero kept trees has nothing to water). Assign trees through the UI so both sides agree.
2. **Trigger the reminder.** Either wait for its schedule, or set `next_run_at` to the past (`update reminders set next_run_at = now() - interval '1 minute' where id = <id>;`) — `tick-reminders` runs every minute. You should see one task per member, with `tree_targets` populated and `surveys_needed` = their tree count, and those trees flipped to `Pending`.
3. **Complete the surveys.** Open the task and submit a survey for each tree in the checklist. The task completes only after all are surveyed, and each surveyed tree's `weekly_watering_status` flips to `Completed`.

_Note:_ the daily `cleanup-completed-tasks` cron is included, but its Edge Function deployment is intentionally **deferred** pending a data-retention decision with the client. Until the function is deployed the cron just no-ops (the request 404s; nothing is deleted), so it's safe to ship.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

**New Survey Form checklist for watering**
<img width="666" height="716" alt="Screenshot 2026-05-30 at 4 36 25 PM" src="https://github.com/user-attachments/assets/b8a809f0-b6b1-4d14-a12b-4ce92fed0b44" />


**Status Updated in Supabase and UI**
<img width="1498" height="602" alt="Screenshot 2026-05-30 at 4 40 44 PM" src="https://github.com/user-attachments/assets/ee12f891-f9ad-4616-8778-2550112ab58c" />

