### PR TITLE
Adds Assignees to Reminders view

### DIFF
--- a/src/components/reminders/ReminderNestedMultiSelectDropdown.tsx
+++ b/src/components/reminders/ReminderNestedMultiSelectDropdown.tsx
@@ -23,6 +23,7 @@ export type NestedMultiSelectGroup = NestedMultiSelectOption & {
 export type NestedMultiSelectValue = Record<string, string[]>;
 
 interface ReminderNestedMultiSelectDropdownProps {
+  triggerClassName?: string;
   disabled?: boolean;
   label: string;
   options: NestedMultiSelectGroup[];
@@ -76,6 +77,7 @@ export default function ReminderNestedMultiSelectDropdown({
   onChange,
   options,
   placeholder = "Select recipients",
+  triggerClassName,
   value,
 }: ReminderNestedMultiSelectDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -149,7 +151,7 @@ export default function ReminderNestedMultiSelectDropdown({
       <span className={reminderFieldLabelClass}>{label}</span>
 
       <DropdownMenu open={!disabled && isOpen} onOpenChange={disabled ? undefined : setIsOpen}>
-        <DropdownMenuTrigger disabled={disabled} className={reminderDropdownTriggerClass}>
+        <DropdownMenuTrigger disabled={disabled} className={cn(reminderDropdownTriggerClass, triggerClassName)}>
           <span
             className={cn(
               "truncate leading-normal [text-box:normal]",

--- a/src/components/reminders/ReminderView.tsx
+++ b/src/components/reminders/ReminderView.tsx
@@ -273,18 +273,17 @@ export default function ReminderView({
             />
           )}
         </div>
-        {!isViewMode && (
-          <div className="flex min-w-0 basis-1/2 text-text-dark">
-            <ReminderNestedMultiSelectDropdown
-              disabled={isReadOnly}
-              label="Assignees"
-              options={assigneeOptions}
-              placeholder="Select assignees"
-              value={form.assignees}
-              onChange={(value) => updateForm("assignees", value)}
-            />
-          </div>
-        )}
+        <div className="flex min-w-0 basis-1/2 text-text-dark">
+          <ReminderNestedMultiSelectDropdown
+            disabled={isReadOnly}
+            triggerClassName={viewInputBackgroundClass}
+            label="Assignees"
+            options={assigneeOptions}
+            placeholder="Select assignees"
+            value={form.assignees}
+            onChange={(value) => updateForm("assignees", value)}
+          />
+        </div>
       </div>
       <div className="flex flex-col gap-4">
         <div className="flex flex-row gap-4">


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

Removes gate on the Reminders view form that excluded the Assignees dropdown. Now, Assignees are visible on view. This should be okay, since only Admins have access to the Reminders page. Happy to discuss or revert this change if we want to keep the gating after all.

### Testing Considerations

N/A

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="1367" height="777" alt="image" src="https://github.com/user-attachments/assets/94e8a10d-733b-4313-8d85-a325292927a9" />

