### PR TITLE
Uses AM/PM time format the Reminders Overview

### DIFF
--- a/src/lib/cron_utils.ts
+++ b/src/lib/cron_utils.ts
@@ -252,7 +252,11 @@ function formatPluralDayName(dayIndex: number): string {
 }
 
 function formatExactTime(hour: number, minute: number): string {
-  return `${hour}:${minute.toString().padStart(2, "0")}`;
+  // 12-hour clock with an AM/PM suffix, matching the rest of the app's time
+  // displays. `hour` is 0–23 (PST wall-clock); both 0 and 12 map to 12.
+  const period = hour < 12 ? "AM" : "PM";
+  const hour12 = hour % 12 === 0 ? 12 : hour % 12;
+  return `${hour12}:${minute.toString().padStart(2, "0")} ${period}`;
 }
 
 function assertInRange(value: number, min: number, max: number, fieldName: string): void {
@@ -654,7 +658,7 @@ export function getCronFormPreview(values: CronFormValues): string {
   return formatCronSummary(cronFormValuesToExpression(values));
 }
 
-/** Returns a human-readable time like "8:00" when hour and minute are simple values. */
+/** Returns a human-readable time like "8:00 AM" when hour and minute are simple values. */
 export function getCronTimeOfDay(expression: string): string {
   const { minute, hour } = parseCronExpression(expression);
   const parsedMinute = parseCronField("minute", minute);
@@ -750,7 +754,7 @@ export function getCronDetails(expression: string): string {
   }
 }
 
-/** Builds the final UI summary, such as "Weekly - Mondays at 8:00". */
+/** Builds the final UI summary, such as "Weekly - Mondays at 8:00 AM". */
 export function formatCronSummary(expression: string): string {
   const repeatLabel = getCronRepeatLabel(expression);
   const details = capitalizeFirstLetter(getCronDetails(expression));


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

Updates the crons parser to return time in AM/PM format. This is more consistent with the rest of the time displays throughout the website.

### Modifications

Updates the `formatExactTime()` function in `crons_utils.ts` to return times in AM/PM format.

Updates docstrings in other functions.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

**Before**

<img width="476" height="699" alt="image" src="https://github.com/user-attachments/assets/4c217efb-8c35-4987-9e3f-7d0d96b8b49e" />


**After**

<img width="470" height="680" alt="image" src="https://github.com/user-attachments/assets/a82e815a-3ef3-4cf2-9db1-d2d0f5aca372" />

