### PR TITLE
Displays appropriate message when no user has no trees

### DIFF
--- a/src/components/TreePageTableWidget.tsx
+++ b/src/components/TreePageTableWidget.tsx
@@ -63,6 +63,7 @@ function TreePageTableWidget({
             onTableReady={onTableReady}
             data={trees}
             cols={treeColumns}
+            isLoading={isLoading}
           />
         )}
       </div>

--- a/src/components/data-table/tree-page-table.tsx
+++ b/src/components/data-table/tree-page-table.tsx
@@ -18,12 +18,14 @@ function TreePageTable({
   cols,
   onRowClick,
   onTableReady,
+  isLoading = false,
 }: {
   className?: string;
   data: TreeSchema[];
   cols: ColumnDef<TreeSchema>[];
   onRowClick: (e: React.MouseEvent<HTMLTableRowElement, MouseEvent>, tree: TreeSchema) => void;
   onTableReady?: (table: TableType<TreeSchema>) => void;
+  isLoading?: boolean;
 }) {
   const table = useTable<TreeSchema>(data, cols, 5);
 
@@ -75,11 +77,20 @@ function TreePageTable({
         </TableRow>
       </TableHeader>
       <TableBody className="divide-y divide-border font-medium">
-        {data.length == 0 ? (
+        {isLoading ? (
           <>
             <TableRow>
               <TableCell className="h-16" columnSpan={cols.length}>
                 <p className="sticky left-1/2 -translate-x-1/2 w-max">Loading trees...</p>
+              </TableCell>
+            </TableRow>
+            {renderPlaceholderRows(4, 1)}
+          </>
+        ) : data.length === 0 ? (
+          <>
+            <TableRow>
+              <TableCell className="h-16" columnSpan={cols.length}>
+                <p className="sticky left-1/2 -translate-x-1/2 w-max">No trees to display.</p>
               </TableCell>
             </TableRow>
             {renderPlaceholderRows(4, 1)}


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

When a tree keeper has no trees associated with them, the Trees page will appropriately say "No trees to display" instead of saying "Loading trees...". This prevents mis- leading messages that imply a stalling fetch request when the user simply has nothing to display.

### Modifications

`src/components/data-table/tree-page-table.tsx` uses the `isLoading` state from the `TreePageTableWidget`

`src/components/TreePageTableWidget.tsx` passes the `isLoading` state forward.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="1489" height="816" alt="image" src="https://github.com/user-attachments/assets/60f9e91b-89aa-4743-be95-d8b22c6bcf57" />

