### PR TITLE
Implements Reminder Message Variables

### DIFF
--- a/src/components/reminders/ReminderView.tsx
+++ b/src/components/reminders/ReminderView.tsx
@@ -11,6 +11,7 @@ import { useMemo, useState } from "react";
 import ReminderLongTextInput from "./ReminderLongTextInput";
 import ReminderToggleArea from "./ReminderToggleArea";
 import { reminderFieldLabelClass } from "./reminderInputStyles";
+import { MESSAGE_VARIABLE_TOKENS } from "@shared/message-variables";
 import { Modal, ModalContent, ModalDescription, ModalFooter, ModalHeader } from "@/components/modal";
 import {
   createCronExpression,
@@ -371,7 +372,7 @@ export default function ReminderView({
       <div className="flex flex-col gap-3">
         <span className={reminderFieldLabelClass}>Message Template</span>
         <div className="flex flex-row flex-wrap gap-2">
-          {["{firstName}", "{treeCount}", "{surveyLink}", "{treeNames}"].map((variable) => (
+          {MESSAGE_VARIABLE_TOKENS.map((variable) => (
             <span key={variable} className="rounded-full bg-table-header px-4 py-1 font-mono text-m text-text-muted">
               {variable}
             </span>

--- a/src/database/database.types.ts
+++ b/src/database/database.types.ts
@@ -438,6 +438,8 @@ export type Database = {
           email_attempts: number;
           member_email: string;
           member_firstname: string;
+          member_tree_count: number;
+          member_tree_names: string;
           task_id: number;
           task_message: string;
           task_title: string;

--- a/supabase/functions/_shared/message-variables.ts
+++ b/supabase/functions/_shared/message-variables.ts
@@ -1,0 +1,23 @@
+// Single source of truth for the variables an author may place in a reminder
+// message body, e.g. "{firstName}". Imported by BOTH runtimes:
+//   - the Next.js reminder form, to render the variable chips, and
+//   - the send-pending-emails edge function, to substitute them per recipient.
+//
+// Keep this file dependency-free (no imports) so the Next bundler and the Deno
+// edge runtime can each consume it. The email resolver is typed
+// `Record<MessageVariable, ...>`, so adding a variable here won't compile until
+// a resolver handles it — that's what keeps the chips and the substitution in
+// lockstep.
+
+/** Variable names supported in a reminder message body. */
+export const MESSAGE_VARIABLES = ["firstName", "treeCount", "treeNames"] as const;
+
+export type MessageVariable = (typeof MESSAGE_VARIABLES)[number];
+
+/** The literal token as it appears in a message body, e.g. "{firstName}". */
+export function messageVariableToken(name: MessageVariable): string {
+  return `{${name}}`;
+}
+
+/** Every token, e.g. ["{firstName}", "{treeCount}", "{treeNames}"]. */
+export const MESSAGE_VARIABLE_TOKENS: string[] = MESSAGE_VARIABLES.map(messageVariableToken);

--- a/supabase/functions/send-pending-emails/index.ts
+++ b/supabase/functions/send-pending-emails/index.ts
@@ -3,6 +3,36 @@ import { Resend } from "npm:resend";
 import { render } from "npm:@react-email/render@1.0.4";
 import * as React from "npm:react@19.0.0";
 import { TaskEmail } from "../_shared/emails/TaskEmail.tsx";
+import { MESSAGE_VARIABLES, messageVariableToken, type MessageVariable } from "../_shared/message-variables.ts";
+
+type EmailJob = {
+  task_id: number;
+  member_email: string;
+  member_firstname: string;
+  member_tree_count: number;
+  member_tree_names: string;
+  task_title: string;
+  task_message: string;
+};
+
+// One resolver per supported variable. Typed Record<MessageVariable, ...> so a
+// new variable added to _shared/message-variables.ts won't compile until it's
+// handled here — keeping the reminder-form chips and this substitution in sync.
+const messageVariableResolvers: Record<MessageVariable, (job: EmailJob) => string> = {
+  firstName: (job) => job.member_firstname ?? "",
+  treeCount: (job) => String(job.member_tree_count ?? 0),
+  treeNames: (job) => job.member_tree_names ?? "",
+};
+
+// Replace each known {token} with the recipient's value. Unknown or misspelled
+// tokens are left untouched (rendered literally) by design.
+function applyMessageVariables(message: string, job: EmailJob): string {
+  let result = message;
+  for (const name of MESSAGE_VARIABLES) {
+    result = result.replaceAll(messageVariableToken(name), messageVariableResolvers[name](job));
+  }
+  return result;
+}
 
 Deno.serve(async () => {
   const supabase = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
@@ -26,7 +56,7 @@ Deno.serve(async () => {
         React.createElement(TaskEmail, {
           firstname: j.member_firstname,
           title: j.task_title,
-          message: j.task_message,
+          message: applyMessageVariables(j.task_message, j),
         }),
       ),
     })),

--- a/supabase/migrations/20260531000000_get_pending_email_jobs_variables.sql
+++ b/supabase/migrations/20260531000000_get_pending_email_jobs_variables.sql
@@ -1,0 +1,73 @@
+-- =============================================================================
+-- ECOSLO: get_pending_email_jobs — expose per-recipient data for message vars
+-- =============================================================================
+-- Reminder message bodies support author variables ({firstName}, {treeCount},
+-- {treeNames}) that are substituted per recipient at email-send time by the
+-- send-pending-emails Edge Function. This adds the data those variables need to
+-- the existing per-(task, assignee) job query so the substitution stays a pure
+-- string replace in the function (no extra round-trips):
+--   * member_tree_count / member_tree_names use the task's tree_targets SNAPSHOT
+--     when present (Watering/Mulching), so the email matches the task's frozen
+--     scope; otherwise they fall back to the member's currently kept trees.
+--
+-- Adding columns changes the return type, so the function is dropped and
+-- recreated. Execute is granted to service_role (the Edge Function's role).
+-- =============================================================================
+
+drop function if exists public.get_pending_email_jobs(integer);
+
+create or replace function public.get_pending_email_jobs(p_limit integer default 100)
+returns table (
+  task_id bigint,
+  assignee_id bigint,
+  member_email text,
+  member_firstname text,
+  task_title text,
+  task_message text,
+  email_attempts integer,
+  member_tree_count integer,
+  member_tree_names text
+)
+language sql stable security definer
+set search_path = public
+as $$
+  select
+    t.id,
+    m.id,
+    m.email,
+    m.firstname,
+    t.title,
+    t.message,
+    t.email_attempts,
+    -- {treeCount}: the task's frozen target list when present, else the
+    -- member's current tree count. (tree_targets is null or non-empty, never
+    -- an empty array, so array_length is null only for non-tree tasks.)
+    coalesce(array_length(t.tree_targets, 1), m.trees_count)::int as member_tree_count,
+    -- {treeNames}: names of the task's snapshotted trees when present, else the
+    -- member's currently kept trees. Empty string when there are none.
+    coalesce(
+      case
+        when t.tree_targets is not null then (
+          select string_agg(coalesce(nullif(tr.common_name, ''), 'Tree #' || tr.ecoslo_num), ', ' order by tr.ecoslo_num)
+          from trees tr
+          where tr.ecoslo_num = any (t.tree_targets)
+        )
+        else (
+          select string_agg(coalesce(nullif(tr.common_name, ''), 'Tree #' || tr.ecoslo_num), ', ' order by tr.ecoslo_num)
+          from trees tr
+          where tr.tree_keeper_id = m.id
+        )
+      end,
+      ''
+    ) as member_tree_names
+  from tasks t
+  cross join lateral unnest(t.assignees) as assignee_id
+  join members m on m.id = assignee_id
+  where t.email_sent_at is null
+    and t.email_attempts < 5  -- give up after 5 attempts; investigate manually
+    and t.is_complete = false
+  order by t.created_at asc
+  limit p_limit;
+$$;
+
+grant execute on function public.get_pending_email_jobs(integer) to service_role;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@shared/message-variables": ["./supabase/functions/_shared/message-variables.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

  Adds support for **user-level variables in reminder message bodies**. An author can write `{firstName}`, `{treeCount}`, or `{treeNames}` in a reminder's message, and each recipient receives a copy with those filled in from their own data.

  The non-obvious decision is *where* the substitution happens. The Reminder → Task flow runs almost entirely in Postgres (`fire_reminder`), and resolving variables there looked expensive — and, worse, impossible to do correctly for **group tasks**, where one shared task row is emailed to many people and can't hold a different `{firstName}` per person. So the substitution happens at **email-send time** instead, in the `send-pending-emails` Edge Function. That layer already expands a task into one row per assignee (via `get_pending_email_jobs`), so per-member variables resolve correctly per recipient — even on group tasks — and it stays a pure in-memory string replace with **no extra database round-trips** (avoiding the
  `a×b` query blow-up that a creation-time approach would have caused).

  #### 1. Single source of truth for the variables

  The supported variable list lives in one dependency-free module, `supabase/functions/_shared/message-variables.ts`. It's imported by **both** runtimes:
  - the **Next.js reminder form**, to render the variable chips, and
  - the **Deno edge function**, to perform the substitution.

  The edge functions are deliberately excluded from the web `tsconfig` (they use Deno-only `npm:`/`jsr:` imports), so the app reaches the shared module through a narrow `tsconfig` path alias (`@shared/message-variables` → that one file). Crucially, the email-side resolver is typed `Record<MessageVariable, …>`, so **adding a variable to the shared list won't compile until a resolver handles it** — the chips and the substitution can't silently drift apart. (This is a deliberate exception to the repo's usual "port into `_shared`" pattern, which is reserved for non-trivial logic like `cron_utils`; a one-line constant is safer shared directly than duplicated.)

  #### 2. Substitution at email-send time

  `send-pending-emails` now runs `applyMessageVariables(message, job)` before rendering each email — a straight `replaceAll` of each known `{token}` with the recipient's value. **Unknown or misspelled tokens are left in place** (rendered literally), so a typo like `{treeCounts}` is visible to the author rather than silently deleted. Output is HTML-escaped by React Email, so injected names/tree names can't break the markup.

  #### 3. Per-recipient data (RPC change)

  `get_pending_email_jobs` is extended to also return `member_tree_count` and `member_tree_names` per `(task, assignee)` row, computed in the same single set-based query. These are **snapshot-aware**: for Watering/Mulching tasks they come from the task's frozen `tree_targets`, so the email matches the task's scope; for other tasks they fall back to the member's currently kept trees. `{firstName}` continues to use the joined `members.firstname`.

  #### 4. Reminder form

  The variable chips now render from the shared constant instead of a hard-coded array, and **`{surveyLink}` has been removed** from the supported set (it had no destination yet and was descoped). The stored `tasks.message` intentionally keeps the raw `{vars}` — substitution is an email-delivery concern, so the in-app task view shows the authored template as-is.

  #### 5. Migrations

  `20260531000000_get_pending_email_jobs_variables.sql` drops and recreates `get_pending_email_jobs` (adding columns changes its return type) and re-grants execute to `service_role`. As always, apply migrations through the CLI rather than the Supabase UI.

  ### Testing Considerations

  1. Create or edit a reminder whose message uses the chips, e.g. `Hi {firstName}, please water your {treeCount} trees: {treeNames}.`
  2. Make the reminder due (`update reminders set next_run_at = now() - interval '1 minute' where id = <id>;`).
  3. Within ~1 min the task is created and `send-pending-emails` runs. The recipient's email should read e.g. "Hi Jordan, please water your 3 trees: Coast Live Oak, …". A misspelled token should appear unchanged.
  4. Group-task check: an `Other` reminder with multiple assignees produces one task but one email per assignee, each personalized.

  ### Pull Request Checklist

  - [x] Code is neat, readable, and works
  - [x] Comments are appropriate
  - [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
  - [x] The developer name is specified
  - [x] The summary is completed
  - [x] Assign reviewers


### Screenshots/Screencast

**Reminder Message Body**

<img width="1381" height="780" alt="image" src="https://github.com/user-attachments/assets/a98d2ec6-abbb-499c-8ed5-094a41375569" />


**Email**

<img width="598" height="390" alt="image" src="https://github.com/user-attachments/assets/d19b6437-2c30-4f68-8c64-c07bf3f77763" />

