### PR TITLE
Adds contact info to surveys

### DIFF
--- a/src/components/tree-detail-modal.tsx
+++ b/src/components/tree-detail-modal.tsx
@@ -42,10 +42,20 @@ type TreeFormState = {
   admin_notes: string;
 };
 
+type SurveySubmitter = {
+  id: number;
+  firstname: string;
+  lastname: string;
+  email: string;
+  phone: string;
+};
+
 type SurveyRow = {
   id: number;
   body: Record<string, unknown> | null;
   created_at: string;
+  /** Live contact for the member who completed the survey; null if not recorded or hidden by RLS. */
+  submitter: SurveySubmitter | null;
 };
 
 const conditionOptions: SelectOption[] = [
@@ -242,11 +252,34 @@ function TreeDetailModalContent({ tree, onOpenChange, onSaved, isAdmin }: Omit<T
       const supabase = createUserLevelClient();
       const { data } = await supabase
         .from("surveys")
-        .select("id, body, created_at")
+        .select("id, body, created_at, submitted_by")
         .in("id", surveyIds!)
         .order("created_at", { ascending: false });
 
-      if (!cancelled) setSurveys((data ?? []) as SurveyRow[]);
+      const rows = data ?? [];
+
+      // Resolve each submitter's live contact in one batched lookup. RLS decides
+      // which member rows are visible; anything hidden or unrecorded stays null
+      // and renders as "contact not recorded".
+      const submitterIds = [...new Set(rows.map((r) => r.submitted_by).filter((id): id is number => id != null))];
+      const contactById = new Map<number, SurveySubmitter>();
+      if (submitterIds.length > 0) {
+        const { data: members } = await supabase
+          .from("members")
+          .select("id, firstname, lastname, email, phone")
+          .in("id", submitterIds);
+        for (const m of members ?? []) contactById.set(m.id, m);
+      }
+
+      if (cancelled) return;
+      setSurveys(
+        rows.map((r) => ({
+          id: r.id,
+          body: r.body,
+          created_at: r.created_at,
+          submitter: r.submitted_by != null ? (contactById.get(r.submitted_by) ?? null) : null,
+        })) as SurveyRow[],
+      );
     }
 
     void loadSurveys();
@@ -804,7 +837,22 @@ function TreeDetailModalContent({ tree, onOpenChange, onSaved, isAdmin }: Omit<T
                           <p className="text-text">Issue: {display(body.issue)}</p>
                           <p className="text-text">Other: {display(body.issueOther)}</p>
                           <p className="text-text">Image Link: {display(body.imageLink)}</p>
-                          <p className="text-text">Admin Contact: {display(body.adminContact)}</p>
+                          {body.adminContact === true ? (
+                            <div className="text-text">
+                              <p>Admin contact: Yes</p>
+                              {survey.submitter ? (
+                                <p className="text-text-muted">
+                                  {survey.submitter.firstname} {survey.submitter.lastname}
+                                  {survey.submitter.email ? ` · ${survey.submitter.email}` : ""}
+                                  {survey.submitter.phone ? ` · ${survey.submitter.phone}` : ""}
+                                </p>
+                              ) : (
+                                <p className="text-text-muted">Contact not recorded.</p>
+                              )}
+                            </div>
+                          ) : (
+                            <p className="text-text">Admin contact: No</p>
+                          )}
                           <div className="mt-3 max-h-40 overflow-y-auto whitespace-pre-wrap break-words">
                             <p className="font-semibold text-text-dark">Notes</p>
                             <p className="text-text">{display(body.notes)}</p>

--- a/src/database/database.types.ts
+++ b/src/database/database.types.ts
@@ -100,6 +100,7 @@ export type Database = {
           body: Json;
           created_at: string;
           id: number;
+          submitted_by: number | null;
           task: number | null;
           tree: number | null;
         };
@@ -107,6 +108,7 @@ export type Database = {
           body: Json;
           created_at?: string;
           id?: number;
+          submitted_by?: number | null;
           task?: number | null;
           tree?: number | null;
         };
@@ -114,10 +116,25 @@ export type Database = {
           body?: Json;
           created_at?: string;
           id?: number;
+          submitted_by?: number | null;
           task?: number | null;
           tree?: number | null;
         };
         Relationships: [
+          {
+            foreignKeyName: "surveys_submitted_by_fkey";
+            columns: ["submitted_by"];
+            isOneToOne: false;
+            referencedRelation: "members";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "surveys_submitted_by_fkey";
+            columns: ["submitted_by"];
+            isOneToOne: false;
+            referencedRelation: "public_members";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "surveys_task_fkey";
             columns: ["task"];

--- a/supabase/migrations/20260531000001_surveys_submitted_by.sql
+++ b/supabase/migrations/20260531000001_surveys_submitted_by.sql
@@ -1,0 +1,35 @@
+-- =============================================================================
+-- ECOSLO: surveys.submitted_by — record who completed a survey
+-- =============================================================================
+-- Surveys ask "May an administrator contact you?" but stored no respondent
+-- identity, so a "yes" left admins unsure who to reach. This adds a nullable
+-- submitted_by FK auto-stamped with the authenticated member via the column
+-- default (current_member_id() reads auth.uid()), which means:
+--   * the survey insert route needs no change and the client cannot spoof it,
+--   * the tree detail view can join the submitter's live contact info, and
+--   * an admin completing a survey on another member's behalf is recorded as
+--     the actual respondent (the case the old flag couldn't disambiguate).
+--
+-- Existing rows, and any insert made outside an authenticated session (e.g. the
+-- service role), get NULL — shown in the UI as "contact not recorded".
+-- ON DELETE SET NULL keeps the survey if the member is later removed.
+-- =============================================================================
+
+-- Add the column first so existing rows simply get NULL (no table rewrite),
+-- then attach the default so only future, authenticated inserts are stamped.
+alter table "public"."surveys"
+  add column "submitted_by" bigint;
+
+alter table "public"."surveys"
+  alter column "submitted_by" set default public.current_member_id();
+
+alter table "public"."surveys"
+  add constraint "surveys_submitted_by_fkey"
+  foreign key ("submitted_by") references "public"."members"("id")
+  on update cascade on delete set null;
+
+create index if not exists "surveys_submitted_by_idx"
+  on "public"."surveys" ("submitted_by");
+
+comment on column "public"."surveys"."submitted_by" is
+  'Member who completed the survey, auto-stamped from current_member_id() on insert. NULL for surveys created outside an authenticated session or before this column existed.';


### PR DESCRIPTION


## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

Surveys where the Admin Contact selection is marked yes will automatically include the contact info
for whoever completed the survey.

### Modifications

Updates the `surveys` Supabase table schema to include a `submitted_by` column. This is done with a migration sql file. This is a foreign key reference to the `members.id` and has a default of NULL to provide backwards compatibility. With all new survey completions, this field is automatically populated using the session information for the active user.

Updates the `src/components/tree-detail-modal.tsx` to include contact information if Admin Contact is marked "Yes". The contact info includes the survey submitter's name, phone number, and email, retrieved from the `members` table.

### Testing Considerations

N/A

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="549" height="741" alt="image" src="https://github.com/user-attachments/assets/ab9c269b-de47-4f42-846f-d32134b24f29" />

