### PR TITLE
fix: adjust navbar css to ignore Safari adblocker issue

### DIFF
--- a/src/components/navbar/SideNavbar.tsx
+++ b/src/components/navbar/SideNavbar.tsx
@@ -159,7 +159,7 @@ export default function SideNavbar() {
   })();
 
   return (
-    <div className="sticky top-0 z-60 flex h-[calc(100vh-24px)] w-38 flex-col rounded-4xl bg-primary p-5">
+    <div className="sticky top-[0px] z-60 flex h-[calc(100vh-24px)] w-38 flex-col rounded-4xl bg-primary p-5">
       <Link href="/" className="flex flex-col items-center justify-center">
         <div className="w-24.5 h-24.5 flex items-center justify-center">
           <Image


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

Navbar on Safari deployment wasn't showing because it was caught by an adblocker. This changes the CSS to avoid the adblocker catch conditions.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

Now appears in deployment preview: 
<img width="1508" height="831" alt="image" src="https://github.com/user-attachments/assets/bed9e2a1-26ab-4102-ae33-c968a82affff" />
