### PR TITLE
Adds Page Link to Task Emails

### DIFF
--- a/supabase/functions/_shared/emails/TaskEmail.tsx
+++ b/supabase/functions/_shared/emails/TaskEmail.tsx
@@ -1,16 +1,29 @@
-import { Body, Container, Head, Heading, Hr, Html, Preview, Section, Text } from "npm:@react-email/components@0.0.36";
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from "npm:@react-email/components@0.0.36";
 import * as React from "npm:react@19.0.0";
 
 export type TaskEmailProps = {
   firstname: string;
   title: string;
   message: string;
+  tasksUrl?: string;
 };
 
 // Styling mirrors the sign-in email (src/components/MagicLinkEmailTemplate.tsx)
 // and globals.css so ECOSLO's emails read as one family. Inline styles only —
 // email clients ignore <style> tags and don't run Tailwind.
-export function TaskEmail({ firstname, title, message }: TaskEmailProps) {
+export function TaskEmail({ firstname, title, message, tasksUrl }: TaskEmailProps) {
   return (
     <Html lang="en">
       <Head />
@@ -28,6 +41,21 @@ export function TaskEmail({ firstname, title, message }: TaskEmailProps) {
             </Heading>
             <Text style={taskMessageStyle}>{message}</Text>
           </Section>
+          {tasksUrl ? (
+            <>
+              <Section style={buttonWrapStyle}>
+                <Button href={tasksUrl} style={buttonStyle}>
+                  View Your Tasks
+                </Button>
+              </Section>
+              <Text style={mutedStyle}>Button not working? Copy and paste this link into your browser:</Text>
+              <Text style={fallbackWrapStyle}>
+                <Link href={tasksUrl} style={fallbackLinkStyle}>
+                  {tasksUrl}
+                </Link>
+              </Text>
+            </>
+          ) : null}
           <Hr style={hrStyle} />
           <Text style={footerStyle}>This is an automated reminder from ECOSLO. 🌱</Text>
         </Container>
@@ -99,6 +127,43 @@ const taskMessageStyle: React.CSSProperties = {
   color: "#6a5f52",
   margin: 0,
   whiteSpace: "pre-wrap",
+};
+
+// Button + fallback link copied from MagicLinkEmailTemplate so both emails
+// share one call-to-action design.
+const buttonWrapStyle: React.CSSProperties = {
+  textAlign: "center",
+  margin: "28px 0",
+};
+
+const buttonStyle: React.CSSProperties = {
+  backgroundColor: "#7b8963",
+  color: "#ffffff",
+  display: "inline-block",
+  padding: "14px 32px",
+  borderRadius: "8px",
+  fontSize: "15px",
+  fontWeight: 600,
+  textDecoration: "none",
+};
+
+const mutedStyle: React.CSSProperties = {
+  fontSize: "13px",
+  lineHeight: "20px",
+  color: "#7d7469",
+  margin: "0 0 6px",
+};
+
+const fallbackWrapStyle: React.CSSProperties = {
+  margin: 0,
+  wordBreak: "break-all",
+};
+
+const fallbackLinkStyle: React.CSSProperties = {
+  fontSize: "13px",
+  color: "#697751",
+  wordBreak: "break-all",
+  textDecoration: "underline",
 };
 
 const hrStyle: React.CSSProperties = {

--- a/supabase/functions/send-pending-emails/index.ts
+++ b/supabase/functions/send-pending-emails/index.ts
@@ -38,6 +38,12 @@ Deno.serve(async () => {
   const supabase = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
   const resend = new Resend(Deno.env.get("RESEND_API_KEY")!);
 
+  // Base URL of the deployed app (set via `supabase secrets set SITE_URL=…`),
+  // used for the "View Your Tasks" button. If unset, the email simply omits
+  // the button rather than sending a broken link.
+  const siteUrl = Deno.env.get("SITE_URL")?.trim().replace(/\/+$/, "");
+  const tasksUrl = siteUrl ? `${siteUrl}/tasks` : undefined;
+
   // Pull up to 100 pending (task, assignee) email jobs
   const { data: jobs, error } = await supabase.rpc("get_pending_email_jobs", {
     p_limit: 100,
@@ -56,6 +62,7 @@ Deno.serve(async () => {
           firstname: j.member_firstname,
           title: j.task_title,
           message: applyMessageVariables(j.task_message, j),
+          tasksUrl,
         }),
       ),
     })),


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

Updates the task emails to include a button and link to the `/tasks` page. Note: if the user isn't signed in already, this will redirect them to the login page. This is intended functionality.

### Modifications

Updates the `TaskEmail.tsx` template to copy the `MagicLinkEmailTemplate` styling for the page button and link.

Updates the `send-pending-emails` Edge Function to resolve the site URL dynamically using a Supabase Secret `SITE_URL`.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="450" height="570" alt="image" src="https://github.com/user-attachments/assets/9bfa9b97-5cf9-41b5-92be-e467d083a085" />

