### PR TITLE
Resolve Message Variables in Task Page

### DIFF
--- a/src/app/(admin)/tasks/page.tsx
+++ b/src/app/(admin)/tasks/page.tsx
@@ -18,9 +18,17 @@ import {
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/dropdown-menu";
 import { useCurrentMember } from "@/hooks/useCurrentProvider";
 import { cn } from "@/lib/utils";
+import {
+  applyTaskMessageVariables,
+  buildTaskVariableContext,
+  EMPTY_TASK_VARIABLE_CONTEXT,
+  resolvePerspectiveMemberIds,
+  type TaskVariableContext,
+} from "@/lib/task-message-variables";
+import { messageVariableToken } from "@shared/message-variables";
 import { Download, Plus, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
 
-async function getTasks(): Promise<TaskSchemaWithNames[]> {
+async function getTasks(): Promise<{ tasks: TaskSchemaWithNames[]; variableContext: TaskVariableContext }> {
   const supabase = createUserLevelClient();
 
   const { data: tasks, error: tasksError } = await supabase
@@ -29,11 +37,12 @@ async function getTasks(): Promise<TaskSchemaWithNames[]> {
     .order("created_at", { ascending: false });
 
   if (tasksError) throw new Error(tasksError.message);
-  if (!tasks || tasks.length === 0) return [];
+  if (!tasks || tasks.length === 0) return { tasks: [], variableContext: EMPTY_TASK_VARIABLE_CONTEXT };
 
   const assigneeIds = Array.from(new Set(tasks.flatMap((task) => task.assignees ?? [])));
 
   let nameById = new Map<number, string>();
+  let memberRows: { id: number | null; firstname: string | null; lastname: string | null }[] = [];
   if (assigneeIds.length > 0) {
     const { data: members, error: membersError } = await supabase
       .from("public_members")
@@ -43,20 +52,40 @@ async function getTasks(): Promise<TaskSchemaWithNames[]> {
     if (membersError) {
       console.error("[tasks] failed to fetch member names:", membersError);
     } else if (members) {
+      memberRows = members;
       nameById = new Map(members.map((m) => [m.id, `${m.firstname} ${m.lastname}`]));
     }
   }
 
-  return tasks.map((task) => ({
-    ...task,
-    names: (task.assignees ?? []).map((id: number) => nameById.get(id) ?? "Unknown"),
-  }));
+  const treeTokens = [messageVariableToken("treeCount"), messageVariableToken("treeNames")];
+  const needsTrees = tasks.some((task) => treeTokens.some((token) => task.message?.includes(token)));
+
+  let treeRows: { ecoslo_num: number | null; common_name: string | null; tree_keeper_id: number | null }[] = [];
+  if (needsTrees) {
+    const { data: trees, error: treesError } = await supabase
+      .from("public_trees")
+      .select("ecoslo_num, common_name, tree_keeper_id");
+
+    if (treesError) {
+      console.error("[tasks] failed to fetch trees for message variables:", treesError);
+    } else if (trees) {
+      treeRows = trees;
+    }
+  }
+
+  return {
+    tasks: tasks.map((task) => ({
+      ...task,
+      names: (task.assignees ?? []).map((id: number) => nameById.get(id) ?? "Unknown"),
+    })),
+    variableContext: buildTaskVariableContext(memberRows, treeRows),
+  };
 }
 
 const PAGE_SIZE_OPTIONS = [5, 10, 25, 50, 100];
 
 export default function Tasks() {
-  const { isAdmin } = useCurrentMember();
+  const { member, isAdmin } = useCurrentMember();
 
   const [status, setStatus] = useState(STATUS_OPTIONS[1]);
   const [surveys, setSurveys] = useState(SURVEY_OPTIONS[0]);
@@ -64,6 +93,7 @@ export default function Tasks() {
   const [assignees, setAssignees] = useState<string[]>([]);
 
   const [tasks, setTasks] = useState<TaskSchemaWithNames[]>([]);
+  const [variableContext, setVariableContext] = useState<TaskVariableContext>(EMPTY_TASK_VARIABLE_CONTEXT);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -78,7 +108,8 @@ export default function Tasks() {
   const fetchTasks = useCallback(async () => {
     try {
       const data = await getTasks();
-      setTasks(data);
+      setTasks(data.tasks);
+      setVariableContext(data.variableContext);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load tasks");
@@ -93,11 +124,29 @@ export default function Tasks() {
   }, [fetchTasks]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
-  const allAssignees = useMemo(() => ["All", ...new Set(tasks.flatMap((task) => task.names))], [tasks]);
+  // Tasks with message variables ({firstName}, …) resolved for display. A
+  // tree keeper sees their own values; an admin sees each task's assignee
+  // values (combined when a group task has several assignees). Raw `message`
+  // is kept untouched for the edit form.
+  const memberId = member?.id ?? null;
+  const displayTasks = useMemo(
+    () =>
+      tasks.map((task) => ({
+        ...task,
+        displayMessage: applyTaskMessageVariables(
+          task,
+          resolvePerspectiveMemberIds(task.assignees ?? [], { isAdmin, memberId }),
+          variableContext,
+        ),
+      })),
+    [tasks, variableContext, isAdmin, memberId],
+  );
+
+  const allAssignees = useMemo(() => ["All", ...new Set(displayTasks.flatMap((task) => task.names))], [displayTasks]);
 
   const filteredTasks = useMemo(
-    () => filterTasks(tasks, status, surveys, assignees, searchQuery),
-    [tasks, status, surveys, assignees, searchQuery],
+    () => filterTasks(displayTasks, status, surveys, assignees, searchQuery),
+    [displayTasks, status, surveys, assignees, searchQuery],
   );
 
   const totalPages = Math.max(1, Math.ceil(filteredTasks.length / pageSize));
@@ -283,7 +332,7 @@ export default function Tasks() {
       <ExportCSVModal
         open={exportModalOpen}
         onOpenChange={setExportModalOpen}
-        allTasks={tasks}
+        allTasks={displayTasks}
         filteredTasks={filteredTasks}
       />
     </>
@@ -321,7 +370,7 @@ function filterTasks(
   const fuse = new Fuse(filteredByControls, {
     keys: [
       { name: "title", weight: 0.3 },
-      { name: "message", weight: 0.3 },
+      { name: "displayMessage", weight: 0.3 },
       { name: "names", weight: 0.2 },
       { name: "id", weight: 0.2 },
     ],

--- a/src/app/(admin)/tasks/page.tsx
+++ b/src/app/(admin)/tasks/page.tsx
@@ -20,9 +20,9 @@ import { useCurrentMember } from "@/hooks/useCurrentProvider";
 import { cn } from "@/lib/utils";
 import {
   applyTaskMessageVariables,
+  buildTaskMessageSegments,
   buildTaskVariableContext,
   EMPTY_TASK_VARIABLE_CONTEXT,
-  resolvePerspectiveMemberIds,
   type TaskVariableContext,
 } from "@/lib/task-message-variables";
 import { messageVariableToken } from "@shared/message-variables";
@@ -124,22 +124,24 @@ export default function Tasks() {
   }, [fetchTasks]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
-  // Tasks with message variables ({firstName}, …) resolved for display. A
-  // tree keeper sees their own values; an admin sees each task's assignee
-  // values (combined when a group task has several assignees). Raw `message`
-  // is kept untouched for the edit form.
+  // Tasks with message variables ({firstName}, …) resolved for display.
+  // `displaySegments` drives the card/modal:
+  //   - a group task shows one anchor member's value + a "+N others" hover
+  //     chip (anchored on this viewer when they're an assignee, else the
+  //     first assignee)
+  //   - a single-assignee task shows that member's plain values. `searchText`
+  //     is the fully-combined plain string so search still matches every
+  //     assignee/tree
+  // Raw `message` is left untouched for the edit form.
   const memberId = member?.id ?? null;
   const displayTasks = useMemo(
     () =>
       tasks.map((task) => ({
         ...task,
-        displayMessage: applyTaskMessageVariables(
-          task,
-          resolvePerspectiveMemberIds(task.assignees ?? [], { isAdmin, memberId }),
-          variableContext,
-        ),
+        displaySegments: buildTaskMessageSegments(task, { memberId }, variableContext),
+        searchText: applyTaskMessageVariables(task, task.assignees ?? [], variableContext),
       })),
-    [tasks, variableContext, isAdmin, memberId],
+    [tasks, variableContext, memberId],
   );
 
   const allAssignees = useMemo(() => ["All", ...new Set(displayTasks.flatMap((task) => task.names))], [displayTasks]);
@@ -370,7 +372,7 @@ function filterTasks(
   const fuse = new Fuse(filteredByControls, {
     keys: [
       { name: "title", weight: 0.3 },
-      { name: "displayMessage", weight: 0.3 },
+      { name: "searchText", weight: 0.3 },
       { name: "names", weight: 0.2 },
       { name: "id", weight: 0.2 },
     ],

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -7,6 +7,8 @@ import { cn } from "@/lib/utils";
 
 export interface TaskSchemaWithNames extends TaskSchema {
   names: string[];
+  /** `message` with variables resolved for the current viewer. */
+  displayMessage?: string;
 }
 
 interface TaskCardProps {
@@ -27,6 +29,7 @@ export function TaskCard({ task, onClick }: TaskCardProps) {
   const isComplete = Boolean(task.is_complete);
   const needsSurvey = (task.surveys_needed ?? 0) > 0;
   const isGroup = (task.assignees?.length ?? 0) > 1;
+  const message = task.displayMessage ?? task.message;
 
   return (
     <button
@@ -39,9 +42,7 @@ export function TaskCard({ task, onClick }: TaskCardProps) {
     >
       <div className="flex flex-col gap-1.5 mb-3">
         {task.title ? <p className="text-text-dark text-base font-serif font-bold leading-snug">{task.title}</p> : null}
-        {task.message ? (
-          <p className="text-text-muted text-sm font-mulish leading-snug line-clamp-2">{task.message}</p>
-        ) : null}
+        {message ? <p className="text-text-muted text-sm font-mulish leading-snug line-clamp-2">{message}</p> : null}
       </div>
 
       <div className="flex flex-wrap items-center gap-2 mb-3">

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -2,13 +2,15 @@
 
 import Badge from "@/components/badge";
 import { TaskSchema } from "@/components/data-table/table-widget-defs";
+import { TaskMessage } from "@/components/TaskMessage";
+import type { MessageSegment } from "@/lib/task-message-variables";
 import { CalendarDays, CheckCircle2, ClipboardList, Users } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface TaskSchemaWithNames extends TaskSchema {
   names: string[];
-  /** `message` with variables resolved for the current viewer. */
-  displayMessage?: string;
+  displaySegments?: MessageSegment[];
+  searchText?: string;
 }
 
 interface TaskCardProps {
@@ -29,7 +31,7 @@ export function TaskCard({ task, onClick }: TaskCardProps) {
   const isComplete = Boolean(task.is_complete);
   const needsSurvey = (task.surveys_needed ?? 0) > 0;
   const isGroup = (task.assignees?.length ?? 0) > 1;
-  const message = task.displayMessage ?? task.message;
+  const segments = task.displaySegments ?? (task.message ? [{ kind: "text" as const, text: task.message }] : []);
 
   return (
     <button
@@ -42,7 +44,11 @@ export function TaskCard({ task, onClick }: TaskCardProps) {
     >
       <div className="flex flex-col gap-1.5 mb-3">
         {task.title ? <p className="text-text-dark text-base font-serif font-bold leading-snug">{task.title}</p> : null}
-        {message ? <p className="text-text-muted text-sm font-mulish leading-snug line-clamp-2">{message}</p> : null}
+        {task.message ? (
+          <p className="text-text-muted text-sm font-mulish leading-snug line-clamp-2">
+            <TaskMessage segments={segments} />
+          </p>
+        ) : null}
       </div>
 
       <div className="flex flex-wrap items-center gap-2 mb-3">

--- a/src/components/TaskDetailModal.tsx
+++ b/src/components/TaskDetailModal.tsx
@@ -352,7 +352,9 @@ function TaskDetailModalContent({ task, onOpenChange, onSaved, isAdmin }: Omit<T
                       {task?.message ? (
                         <div className="flex flex-col items-start gap-y-1">
                           <p className="text-text-muted font-semibold">Message</p>
-                          <p className="text-text-dark font-medium whitespace-pre-wrap">{task.message}</p>
+                          <p className="text-text-dark font-medium whitespace-pre-wrap">
+                            {task.displayMessage ?? task.message}
+                          </p>
                         </div>
                       ) : null}
                     </>

--- a/src/components/TaskDetailModal.tsx
+++ b/src/components/TaskDetailModal.tsx
@@ -15,6 +15,7 @@ import { dropdownContentClassName, dropdownItemClassName, selectTriggerClassName
 import Badge from "@/components/badge";
 import { Check, CheckCircle2, ChevronDown, ClipboardList, Pencil, Trash2, Undo2, Users, X } from "lucide-react";
 import type { TaskSchemaWithNames } from "@/components/TaskCard";
+import { TaskMessage } from "@/components/TaskMessage";
 import TaskSurveyForm from "@/components/survey/TaskSurveyForm";
 import { createUserLevelClient } from "@/lib/supabase/client";
 import { useCurrentMember } from "@/hooks/useCurrentProvider";
@@ -349,11 +350,12 @@ function TaskDetailModalContent({ task, onOpenChange, onSaved, isAdmin }: Omit<T
                     </>
                   ) : (
                     <>
+                      {/* Display resolves {message variables}; the edit textarea keeps the raw tokens. */}
                       {task?.message ? (
                         <div className="flex flex-col items-start gap-y-1">
                           <p className="text-text-muted font-semibold">Message</p>
                           <p className="text-text-dark font-medium whitespace-pre-wrap">
-                            {task.displayMessage ?? task.message}
+                            <TaskMessage segments={task.displaySegments ?? [{ kind: "text", text: task.message }]} />
                           </p>
                         </div>
                       ) : null}

--- a/src/components/TaskMessage.tsx
+++ b/src/components/TaskMessage.tsx
@@ -1,0 +1,27 @@
+import { Fragment } from "react";
+import { Tooltip } from "@/components/ui/tooltip";
+import type { MessageSegment } from "@/lib/task-message-variables";
+
+interface TaskMessageProps {
+  segments: MessageSegment[];
+}
+
+// Renders a task message whose {variables} have been resolved into segments.
+// Plain text renders inline; a group task's "anchor +N others" segments
+// become hover chips that reveal everyone. Inline only, so callers control
+// the wrapping <p> (line clamp, pre-wrap, etc.).
+export function TaskMessage({ segments }: TaskMessageProps) {
+  return (
+    <>
+      {segments.map((segment, i) =>
+        segment.kind === "chip" ? (
+          <Tooltip key={i} label={segment.tooltip}>
+            {segment.text}
+          </Tooltip>
+        ) : (
+          <Fragment key={i}>{segment.text}</Fragment>
+        ),
+      )}
+    </>
+  );
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+
+interface TooltipProps {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}
+
+type Placement = { left: number; top: number; above: boolean };
+
+export function Tooltip({ label, children, className }: TooltipProps) {
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const [placement, setPlacement] = useState<Placement | null>(null);
+
+  const show = () => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    // Prefer above; flip below when too close to the top of the viewport.
+    const above = rect.top > 56;
+    setPlacement({
+      left: rect.left + rect.width / 2,
+      top: above ? rect.top - 8 : rect.bottom + 8,
+      above,
+    });
+  };
+  const hide = () => setPlacement(null);
+
+  return (
+    <>
+      <span
+        ref={triggerRef}
+        title={label}
+        onMouseEnter={show}
+        onMouseLeave={hide}
+        className={cn("cursor-help underline decoration-dotted decoration-text-muted underline-offset-2", className)}
+      >
+        {children}
+      </span>
+      {placement
+        ? createPortal(
+            <div
+              role="tooltip"
+              style={{
+                position: "fixed",
+                left: placement.left,
+                top: placement.top,
+                transform: `translateX(-50%) translateY(${placement.above ? "-100%" : "0"})`,
+              }}
+              className="pointer-events-none z-[60] max-w-xs whitespace-normal break-words rounded-md bg-text-dark px-2.5 py-1.5 text-xs font-medium text-white shadow-md"
+            >
+              {label}
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/src/lib/task-message-variables.ts
+++ b/src/lib/task-message-variables.ts
@@ -7,9 +7,11 @@
 //   * unknown or misspelled tokens are left literal, by design.
 //
 // One UI-only divergence: an email is one (task, recipient) pair, but a group
-// task renders as a single card. Admins therefore see the COMBINED values of
-// all assignees (names joined, tree counts summed); a tree keeper viewing a
-// shared task still sees only their own values, matching the email they got.
+// task (>1 assignee) renders as a single card. There it shows one anchor
+// member's value followed by "+N others". The anchor is the viewer when
+// they're an assignee, otherwise the first assignee. The chip is hoverable
+// and displays a tooltip. applyTaskMessageVariables keeps returning the
+// fully-combined plain string, used for search/CSV.
 
 import { MESSAGE_VARIABLES, messageVariableToken, type MessageVariable } from "@shared/message-variables";
 
@@ -53,21 +55,6 @@ export function buildTaskVariableContext(
   }
 
   return { firstnameById, treesByKeeperId, treeByEcosloNum };
-}
-
-/**
- * Whose values a task's message variables should reflect for the current
- * viewer: a tree keeper assigned to the task sees their own values (matching
- * the email they received); admins see every assignee's values combined.
- */
-export function resolvePerspectiveMemberIds(
-  assignees: readonly number[],
-  viewer: { isAdmin: boolean; memberId: number | null },
-): number[] {
-  if (!viewer.isAdmin && viewer.memberId !== null && assignees.includes(viewer.memberId)) {
-    return [viewer.memberId];
-  }
-  return [...assignees];
 }
 
 type TaskForVariables = {
@@ -135,4 +122,105 @@ export function applyTaskMessageVariables(
     result = result.replaceAll(token, messageVariableResolvers[name](task, memberIds, context, targets));
   }
   return result;
+}
+
+// Segmented rendering for the Tasks page
+export type MessageSegment = { kind: "text"; text: string } | { kind: "chip"; text: string; tooltip: string };
+
+type GroupTask = TaskForVariables & { assignees: number[] | null };
+
+// "Bob" + 2 -> "Bob +2 others"; "Bob" + 1 -> "Bob +1 other";
+// "Bob" + 0 -> "Bob" (nothing extra); "" + 5 -> "+5 others" (anchor has none).
+function withOthersSuffix(anchorValue: string, otherCount: number): string {
+  if (otherCount <= 0) return anchorValue;
+  const suffix = `+${otherCount} ${otherCount === 1 ? "other" : "others"}`;
+  return anchorValue ? `${anchorValue} ${suffix}` : suffix;
+}
+
+// How one variable renders inside a group task: `text` is what's shown; when
+// `tooltip` is set the segment becomes a hover chip revealing every member's
+// value. otherCount can be 0 for tree variables (the other members keep no
+// trees), in which case there's nothing extra to reveal and it stays text.
+type GroupVariableRender = { text: string; tooltip?: string };
+
+function groupVariableRenders(
+  assignees: number[],
+  anchorId: number,
+  ctx: TaskVariableContext,
+): Record<MessageVariable, GroupVariableRender> {
+  const firstnameOf = (id: number) => ctx.firstnameById.get(id) ?? "";
+  const treeCountOf = (id: number) => (ctx.treesByKeeperId.get(id) ?? []).length;
+  const treesOf = (id: number) => [...(ctx.treesByKeeperId.get(id) ?? [])].sort(byEcosloNum);
+  const allTrees = assignees.flatMap((id) => ctx.treesByKeeperId.get(id) ?? []).sort(byEcosloNum);
+
+  const anchorTrees = treesOf(anchorId);
+  const otherTreeCount = allTrees.length - anchorTrees.length;
+
+  return {
+    // Anchor's first name + count of the OTHER members; tooltip lists everyone
+    // in assignee order.
+    firstName: {
+      text: withOthersSuffix(firstnameOf(anchorId), assignees.length - 1),
+      tooltip: assignees.map(firstnameOf).filter(Boolean).join(", "),
+    },
+    // Anchor's tree count + count of every OTHER member's trees; tooltip breaks
+    // the total down per member so the numbers are accountable.
+    treeCount: {
+      text: withOthersSuffix(String(anchorTrees.length), otherTreeCount),
+      tooltip:
+        otherTreeCount > 0
+          ? assignees.map((id) => `${firstnameOf(id) || "Unknown"}: ${treeCountOf(id)}`).join(", ")
+          : undefined,
+    },
+    // Anchor's tree names + count of the OTHER trees; tooltip lists them all.
+    treeNames: {
+      text: withOthersSuffix(anchorTrees.map(treeDisplayName).join(", "), otherTreeCount),
+      tooltip: otherTreeCount > 0 ? allTrees.map(treeDisplayName).join(", ") : undefined,
+    },
+  };
+}
+
+const TOKEN_SPLIT_PATTERN = new RegExp(
+  `(${MESSAGE_VARIABLES.map((name) => messageVariableToken(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})`,
+);
+const TOKEN_TO_VARIABLE = new Map<string, MessageVariable>(
+  MESSAGE_VARIABLES.map((name) => [messageVariableToken(name), name]),
+);
+
+/**
+ * Splits a task's message into renderable segments. Non-group tasks collapse to a
+ * single plain-text segment via applyTaskMessageVariables. Group tasks anchor
+ * each variable on the viewer (or the first assignee) and turn it into a "+N
+ * others" chip; unknown tokens stay literal in either case.
+ */
+export function buildTaskMessageSegments(
+  task: GroupTask,
+  viewer: { memberId: number | null },
+  context: TaskVariableContext,
+): MessageSegment[] {
+  const assignees = task.assignees ?? [];
+
+  if (assignees.length <= 1) {
+    return [{ kind: "text", text: applyTaskMessageVariables(task, assignees, context) }];
+  }
+
+  const anchorId = viewer.memberId !== null && assignees.includes(viewer.memberId) ? viewer.memberId : assignees[0];
+  const renders = groupVariableRenders(assignees, anchorId, context);
+
+  const segments: MessageSegment[] = [];
+  for (const part of task.message.split(TOKEN_SPLIT_PATTERN)) {
+    if (part === "") continue;
+    const variable = TOKEN_TO_VARIABLE.get(part);
+    if (!variable) {
+      segments.push({ kind: "text", text: part });
+      continue;
+    }
+    const render = renders[variable];
+    segments.push(
+      render.tooltip
+        ? { kind: "chip", text: render.text, tooltip: render.tooltip }
+        : { kind: "text", text: render.text },
+    );
+  }
+  return segments;
 }

--- a/src/lib/task-message-variables.ts
+++ b/src/lib/task-message-variables.ts
@@ -1,0 +1,138 @@
+// Client-side mirror of the per-recipient {firstName}/{treeCount}/{treeNames}
+// substitution the send-pending-emails edge function performs. The Tasks
+// page displays the same message bodies, so it resolves the same tokens from
+// data the browser can read (public_members / public_trees):
+//   * tree variables use the task's tree_targets SNAPSHOT when present
+//     (Watering/Mulching), else the member's currently kept trees;
+//   * unknown or misspelled tokens are left literal, by design.
+//
+// One UI-only divergence: an email is one (task, recipient) pair, but a group
+// task renders as a single card. Admins therefore see the COMBINED values of
+// all assignees (names joined, tree counts summed); a tree keeper viewing a
+// shared task still sees only their own values, matching the email they got.
+
+import { MESSAGE_VARIABLES, messageVariableToken, type MessageVariable } from "@shared/message-variables";
+
+export type TreeVariableInfo = {
+  ecosloNum: number;
+  commonName: string | null;
+};
+
+export type TaskVariableContext = {
+  firstnameById: ReadonlyMap<number, string>;
+  treesByKeeperId: ReadonlyMap<number, TreeVariableInfo[]>;
+  treeByEcosloNum: ReadonlyMap<number, TreeVariableInfo>;
+};
+
+export const EMPTY_TASK_VARIABLE_CONTEXT: TaskVariableContext = {
+  firstnameById: new Map(),
+  treesByKeeperId: new Map(),
+  treeByEcosloNum: new Map(),
+};
+
+export function buildTaskVariableContext(
+  members: ReadonlyArray<{ id: number | null; firstname: string | null }>,
+  trees: ReadonlyArray<{ ecoslo_num: number | null; common_name: string | null; tree_keeper_id: number | null }>,
+): TaskVariableContext {
+  const firstnameById = new Map<number, string>();
+  for (const m of members) {
+    if (m.id !== null) firstnameById.set(m.id, m.firstname ?? "");
+  }
+
+  const treesByKeeperId = new Map<number, TreeVariableInfo[]>();
+  const treeByEcosloNum = new Map<number, TreeVariableInfo>();
+  for (const t of trees) {
+    if (t.ecoslo_num === null) continue;
+    const info: TreeVariableInfo = { ecosloNum: t.ecoslo_num, commonName: t.common_name };
+    treeByEcosloNum.set(info.ecosloNum, info);
+    if (t.tree_keeper_id !== null) {
+      const kept = treesByKeeperId.get(t.tree_keeper_id);
+      if (kept) kept.push(info);
+      else treesByKeeperId.set(t.tree_keeper_id, [info]);
+    }
+  }
+
+  return { firstnameById, treesByKeeperId, treeByEcosloNum };
+}
+
+/**
+ * Whose values a task's message variables should reflect for the current
+ * viewer: a tree keeper assigned to the task sees their own values (matching
+ * the email they received); admins see every assignee's values combined.
+ */
+export function resolvePerspectiveMemberIds(
+  assignees: readonly number[],
+  viewer: { isAdmin: boolean; memberId: number | null },
+): number[] {
+  if (!viewer.isAdmin && viewer.memberId !== null && assignees.includes(viewer.memberId)) {
+    return [viewer.memberId];
+  }
+  return [...assignees];
+}
+
+type TaskForVariables = {
+  message: string;
+  tree_targets: number[] | null;
+};
+
+// Matches the SQL: coalesce(nullif(common_name, ''), 'Tree #' || ecoslo_num).
+function treeDisplayName(tree: TreeVariableInfo): string {
+  return tree.commonName || `Tree #${tree.ecosloNum}`;
+}
+
+function byEcosloNum(a: TreeVariableInfo, b: TreeVariableInfo): number {
+  return a.ecosloNum - b.ecosloNum;
+}
+
+// The trees the task's tree variables describe: the frozen tree_targets
+// snapshot when present (targets pointing at since-deleted trees are dropped
+// from names, like the SQL join), else the members' currently kept trees.
+function variableTrees(targets: number[] | null, memberIds: number[], ctx: TaskVariableContext): TreeVariableInfo[] {
+  const trees = targets
+    ? targets.flatMap((num) => ctx.treeByEcosloNum.get(num) ?? [])
+    : memberIds.flatMap((id) => ctx.treesByKeeperId.get(id) ?? []);
+  return trees.sort(byEcosloNum);
+}
+
+// One resolver per supported variable, typed Record<MessageVariable, ...> for
+// the same compile-time lockstep the edge function relies on: a new variable
+// added to _shared/message-variables.ts won't compile until it's handled here.
+const messageVariableResolvers: Record<
+  MessageVariable,
+  (task: TaskForVariables, memberIds: number[], ctx: TaskVariableContext, targets: number[] | null) => string
+> = {
+  firstName: (_task, memberIds, ctx) =>
+    memberIds
+      .map((id) => ctx.firstnameById.get(id) ?? "")
+      .filter(Boolean)
+      .join(", "),
+  // Snapshot count is the snapshot's length even if a target tree has since
+  // been deleted — mirrors array_length(tree_targets, 1) in the SQL.
+  treeCount: (_task, memberIds, ctx, targets) =>
+    String(targets ? targets.length : variableTrees(null, memberIds, ctx).length),
+  treeNames: (_task, memberIds, ctx, targets) => variableTrees(targets, memberIds, ctx).map(treeDisplayName).join(", "),
+};
+
+/**
+ * Replaces each known {token} in the task's message with the values for the
+ * given members. Unknown tokens stay literal, matching the email behavior.
+ */
+export function applyTaskMessageVariables(
+  task: TaskForVariables,
+  memberIds: number[],
+  context: TaskVariableContext,
+): string {
+  if (!task.message.includes("{")) return task.message;
+
+  // tree_targets is null or non-empty in practice; treat an empty array like
+  // null so the fallback matches array_length(...) being null in the SQL.
+  const targets = task.tree_targets?.length ? task.tree_targets : null;
+
+  let result = task.message;
+  for (const name of MESSAGE_VARIABLES) {
+    const token = messageVariableToken(name);
+    if (!result.includes(token)) continue;
+    result = result.replaceAll(token, messageVariableResolvers[name](task, memberIds, context, targets));
+  }
+  return result;
+}


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

Updates the task page to resolve message variables the same way the Supabase Edge Function resolves them in emails. In all cases, variable resolution runs on who the task is assigned to.

Since Tree Keepers only see tasks related to them, the variable resolutions will always appear to be about them (e.g. `{firstName}` will always be the current Tree Keeper's first name).

Since Admins see all tasks, the variable resolutions will appear with other people's information.

The only edge case is with Group Tasks. I currently set it up so a group task will display **all** members' information in the group. For example, a group task that has all the admins as the assignees will display each admin's name for the `{firstName}` variable resolution. I'm not sure if this is desirable. Another option is to just display the current user's information, though this may be misleading (an admin may think a group task is their sole responsibility when in reality, it belongs to all the assignees). Another option is to just keep the raw message variables (e.g. `{treeCount}`) in the case of a group task.

Happy to consider other approaches as well, and make any changes necessary!

### Modifications

{list out the files created/modified and a brief description of what was changed}

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

**Group Task: unresolved variables (before)**

<img width="695" height="639" alt="image" src="https://github.com/user-attachments/assets/475d58bb-5396-4f3d-929e-1fe1ebc640ba" />

**Group Task: resolves to all assignees (after this PR)**

<img width="635" height="630" alt="image" src="https://github.com/user-attachments/assets/6236eb21-915e-448b-a946-6c8c18ca20c0" />
