### PR TITLE
UI Overhall for Mobile Compatibility

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,5 +1,4 @@
-import SideNavbar from "@/components/navbar/SideNavbar";
-import { CurrentMemberProvider } from "@/hooks/useCurrentProvider";
+import { AppShell } from "@/components/app-shell";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -8,14 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <CurrentMemberProvider>
-      <div className="flex h-screen bg-background">
-        <div className="flex items-center pl-3">
-          <SideNavbar />
-        </div>
-        <div className="flex-1 min-w-0 overflow-y-auto">{children}</div>
-      </div>
-    </CurrentMemberProvider>
-  );
+  return <AppShell>{children}</AppShell>;
 }

--- a/src/app/(admin)/reminders/page.tsx
+++ b/src/app/(admin)/reminders/page.tsx
@@ -7,11 +7,16 @@ import { AppButton } from "@/components/ui/form-controls";
 import { Plus } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { AdminPageShell } from "@/components/admin-page-shell";
+import { cn } from "@/lib/utils";
 
 type Member = Tables<"members">;
 type Reminder = Tables<"reminders">;
 type Template = Tables<"templates">;
 type ReminderViewMode = "create" | "edit" | "view";
+// Below md only one pane fits, so the page swaps between the overview list
+// and the editor; both stay mounted (just hidden) so desktop and form state
+// are unaffected.
+type MobilePane = "list" | "editor";
 
 export default function Reminders() {
   const [members, setMembers] = useState<Member[]>([]);
@@ -19,6 +24,7 @@ export default function Reminders() {
   const [templates, setTemplates] = useState<Template[]>([]);
   const [selectedReminderId, setSelectedReminderId] = useState<number | null>(null);
   const [reminderViewMode, setReminderViewMode] = useState<ReminderViewMode>("create");
+  const [mobilePane, setMobilePane] = useState<MobilePane>("list");
 
   useEffect(() => {
     const fetchData = async () => {
@@ -47,11 +53,21 @@ export default function Reminders() {
   const handleCreateReminder = () => {
     setSelectedReminderId(null);
     setReminderViewMode("create");
+    setMobilePane("editor");
+  };
+
+  // Cancel resets the editor like handleCreateReminder, but on mobile it
+  // returns to the list instead of leaving a blank editor on screen.
+  const handleCancelEdit = () => {
+    setSelectedReminderId(null);
+    setReminderViewMode("create");
+    setMobilePane("list");
   };
 
   const handleSelectReminder = (reminderId: number) => {
     setSelectedReminderId(reminderId);
     setReminderViewMode("view");
+    setMobilePane("editor");
   };
 
   const handleEditReminder = () => {
@@ -77,12 +93,13 @@ export default function Reminders() {
     setReminders((currentReminders) => currentReminders.filter((reminder) => reminder.id !== deletedReminderId));
     setSelectedReminderId(null);
     setReminderViewMode("create");
+    setMobilePane("list");
   };
 
   return (
     <AdminPageShell
       title="Reminders"
-      className="h-screen overflow-hidden"
+      className="h-full overflow-hidden"
       contentClassName="h-full min-h-0"
       actions={
         <AppButton icon={Plus} radius="small" onClick={handleCreateReminder}>
@@ -90,8 +107,8 @@ export default function Reminders() {
         </AppButton>
       }
     >
-      <div className="flex min-h-0 flex-1 flex-row gap-8">
-        <div className="min-h-0 basis-1/3">
+      <div className="flex min-h-0 flex-1 flex-col gap-6 md:flex-row md:gap-8">
+        <div className={cn("min-h-0 flex-1 md:grow-0 md:basis-1/3", mobilePane === "editor" && "max-md:hidden")}>
           <RemindersList
             reminders={reminders}
             assigneeLabels={assigneeLabels}
@@ -99,13 +116,14 @@ export default function Reminders() {
             onSelectReminder={handleSelectReminder}
           />
         </div>
-        <div className="min-h-0 basis-2/3">
+        <div className={cn("min-h-0 flex-1 md:grow-0 md:basis-2/3", mobilePane === "list" && "max-md:hidden")}>
           <ReminderView
             key={`${selectedReminder?.id ?? "new"}-${members.length}`}
             assigneeLabel={selectedAssigneeLabel}
             members={members}
             mode={reminderViewMode}
-            onCancel={handleCreateReminder}
+            onBack={() => setMobilePane("list")}
+            onCancel={handleCancelEdit}
             onDeleted={handleReminderDeleted}
             onEdit={handleEditReminder}
             onSaved={handleReminderSaved}

--- a/src/app/(admin)/tasks/page.tsx
+++ b/src/app/(admin)/tasks/page.tsx
@@ -239,7 +239,10 @@ export default function Tasks() {
                     </p>
                     <DropdownMenu open={pageSizeOpen} onOpenChange={setPageSizeOpen}>
                       <DropdownMenuTrigger
-                        className={cn(selectTriggerClassName, "min-h-8 w-16 rounded-lg px-2 py-1 lg:w-20 lg:px-3")}
+                        className={cn(
+                          selectTriggerClassName,
+                          "min-h-8 max-lg:w-16 rounded-lg px-2 py-1 lg:w-20 lg:px-3",
+                        )}
                       >
                         <span>{pageSize}</span>
                         <ChevronDown
@@ -270,7 +273,7 @@ export default function Tasks() {
                     <button
                       type="button"
                       className={appButtonClassName({
-                        className: "hidden lg:inline-flex",
+                        className: "max-lg:hidden",
                         iconOnly: true,
                         variant: "secondary",
                       })}
@@ -305,7 +308,7 @@ export default function Tasks() {
                     <button
                       type="button"
                       className={appButtonClassName({
-                        className: "hidden lg:inline-flex",
+                        className: "max-lg:hidden",
                         iconOnly: true,
                         variant: "secondary",
                       })}

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,5 +1,4 @@
-import SideNavbar from "@/components/navbar/SideNavbar";
-import { CurrentMemberProvider } from "@/hooks/useCurrentProvider";
+import { AppShell } from "@/components/app-shell";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -8,14 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function PublicLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <CurrentMemberProvider>
-      <div className="flex h-screen bg-background">
-        <div className="flex items-center pl-3">
-          <SideNavbar />
-        </div>
-        <div className="flex-1 min-w-0 overflow-y-auto">{children}</div>
-      </div>
-    </CurrentMemberProvider>
-  );
+  return <AppShell>{children}</AppShell>;
 }

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -36,14 +36,16 @@ function isValidEmail(email: string): boolean {
 
 function LoginShell({ children }: { children: ReactNode }) {
   return (
-    <main className="flex min-h-screen w-full flex-1 items-center justify-center bg-off-white px-6 py-10">
+    <main className="flex min-h-full w-full flex-1 items-center justify-center bg-off-white px-4 py-8 sm:px-6 sm:py-10">
       {children}
     </main>
   );
 }
 
 function LoginCard({ children }: { children: ReactNode }) {
-  return <section className="w-full max-w-[430px] rounded-2xl bg-card px-8 py-7 shadow-soft">{children}</section>;
+  return (
+    <section className="w-full max-w-[430px] rounded-2xl bg-card px-6 py-7 shadow-soft sm:px-8">{children}</section>
+  );
 }
 
 export default function LoginPage() {

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -349,7 +349,7 @@ export default function ControlPanel({ tableRef }: ControlPanelProps) {
         <ControlStatusPills
           className="flex-1"
           containerClassName="w-full h-full"
-          buttonClassName="flex-1 min-w-0"
+          buttonClassName="min-w-0 sm:flex-1"
           options={CONTROL_STATUS_OPTIONS}
           activeIndex={statusActiveIndex}
           onActiveIndexChange={setStatusActiveIndex}

--- a/src/components/MapClient.tsx
+++ b/src/components/MapClient.tsx
@@ -255,8 +255,8 @@ export default function MapClient() {
   };
 
   return (
-    <main className="flex-1 w-full min-h-screen bg-off-white">
-      <div className="isolate relative h-screen w-full overflow-hidden bg-off-white">
+    <main className="h-full w-full bg-off-white">
+      <div className="isolate relative h-full w-full overflow-hidden bg-off-white">
         <div ref={mapContainerRef} className="absolute inset-0 z-0 h-full w-full" />
 
         <div className="pointer-events-none absolute inset-0 z-10 p-6 max-md:p-4">
@@ -289,7 +289,7 @@ export default function MapClient() {
               </button>
             </div>
 
-            <div className="pointer-events-auto w-fit rounded-2xl border border-border bg-off-white px-5 py-4 shadow-map-control">
+            <div className="pointer-events-auto min-w-0 flex-1 rounded-2xl border border-border bg-off-white px-4 py-3 shadow-map-control md:flex-none md:w-fit md:px-5 md:py-4">
               <MapControlPanel trees={locations} onFilter={setFilteredLocations} onCenter={handleCenter} />
             </div>
           </div>

--- a/src/components/MapPopout.tsx
+++ b/src/components/MapPopout.tsx
@@ -122,8 +122,8 @@ export default function MapPopout({ tree, onClose }: MapPopoutProps) {
   if (!tree) return null;
 
   return (
-    <aside className="absolute right-0 top-0 z-20 flex h-full w-full max-w-md flex-col bg-off-white px-7 py-9 shadow-panel max-md:bottom-0 max-md:top-auto max-md:h-3/4 max-md:max-w-none max-md:rounded-t-3xl max-md:px-5">
-      <div className="mb-7 flex items-start justify-between gap-4">
+    <aside className="absolute right-0 top-0 z-20 flex h-full w-full max-w-md flex-col bg-off-white px-7 py-9 shadow-panel max-md:bottom-0 max-md:top-auto max-md:h-3/4 max-md:max-w-none max-md:rounded-t-3xl max-md:px-5 max-md:py-5">
+      <div className="mb-7 flex items-start justify-between gap-4 max-md:mb-4">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-3">
             <h2 className="font-serif text-3xl font-medium leading-none text-text">#{tree.id}</h2>
@@ -159,7 +159,7 @@ export default function MapPopout({ tree, onClose }: MapPopoutProps) {
         </InfoBlock>
       </div>
 
-      <div className="mt-7 border-t border-border pt-6">
+      <div className="mt-7 border-t border-border pt-6 max-md:mt-4 max-md:pt-4">
         <AppButton
           type="button"
           className="mb-3 w-full"
@@ -174,8 +174,8 @@ export default function MapPopout({ tree, onClose }: MapPopoutProps) {
         </AppButton>
       </div>
       {isReporting ? (
-        <div className="fixed inset-0 z-30 flex items-center justify-center bg-text/45 px-4">
-          <div className="w-full max-w-xl overflow-hidden rounded-3xl bg-off-white p-8 shadow-2xl">
+        <div className="fixed inset-0 z-30 flex items-center justify-center bg-text/45 p-4">
+          <div className="max-h-[calc(100dvh-2rem)] w-full max-w-xl overflow-y-auto rounded-3xl bg-off-white p-5 shadow-2xl md:p-8">
             <div className="mb-5 flex items-start justify-between gap-4">
               <div>
                 <h2 className="font-serif text-3xl font-normal leading-none text-text">Report an Issue</h2>

--- a/src/components/MembersControlPanel.tsx
+++ b/src/components/MembersControlPanel.tsx
@@ -29,7 +29,7 @@ export default function MembersControlPanel({ tableRef }: { tableRef: MutableRef
       <ControlStatusPills
         className="flex-1"
         containerClassName="w-full h-full"
-        buttonClassName="flex-1 min-w-0"
+        buttonClassName="min-w-0 sm:flex-1"
         options={ROLE_STATUS_OPTIONS}
         activeIndex={roleActiveIndex}
         onActiveIndexChange={setRoleActiveIndex}

--- a/src/components/TaskDetailModal.tsx
+++ b/src/components/TaskDetailModal.tsx
@@ -600,10 +600,11 @@ function TaskDetailModalContent({ task, onOpenChange, onSaved, isAdmin }: Omit<T
             <ModalFooter>
               <div className="flex flex-col w-full gap-y-4">
                 <div className="bg-border h-px w-full" />
-                <div className="flex justify-end gap-x-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:justify-end sm:gap-x-4">
                   <AppButton
                     type="button"
                     variant="secondary"
+                    className="w-full sm:w-auto"
                     onClick={(event) => {
                       event.stopPropagation();
                       handleClose(false);
@@ -612,7 +613,7 @@ function TaskDetailModalContent({ task, onOpenChange, onSaved, isAdmin }: Omit<T
                     Cancel
                   </AppButton>
                   {isEditing ? (
-                    <AppButton disabled={isSubmitting || !hasFormChanges} type="submit">
+                    <AppButton className="w-full sm:w-auto" disabled={isSubmitting || !hasFormChanges} type="submit">
                       {isSubmitting
                         ? isAddingTask
                           ? "Creating…"
@@ -627,13 +628,20 @@ function TaskDetailModalContent({ task, onOpenChange, onSaved, isAdmin }: Omit<T
                         <AppButton
                           type="button"
                           variant={isComplete ? "primary" : "secondary"}
+                          className="w-full sm:w-auto"
                           onClick={handleShowSurvey}
                         >
                           {isComplete ? "Submit Additional Survey" : "Submit Survey"}
                         </AppButton>
                       ) : null}
                       {!isComplete ? (
-                        <AppButton type="button" variant="primary" onClick={handleComplete} disabled={completing}>
+                        <AppButton
+                          type="button"
+                          variant="primary"
+                          className="w-full sm:w-auto"
+                          onClick={handleComplete}
+                          disabled={completing}
+                        >
                           {completing
                             ? "Completing…"
                             : requiredSurveyOutstanding

--- a/src/components/TaskDetailModal.tsx
+++ b/src/components/TaskDetailModal.tsx
@@ -383,14 +383,14 @@ function TaskDetailModalContent({ task, onOpenChange, onSaved, isAdmin }: Omit<T
         </ModalHeader>
 
         {showSurvey && !isAddingTask ? (
-          <ModalDescription className="flex flex-col gap-y-4 py-4 overflow-y-auto max-h-[70vh]">
+          <ModalDescription className="flex flex-col gap-y-4 py-4 overflow-y-auto max-h-[60dvh] md:max-h-[70vh]">
             <div className="bg-foreground p-6 border border-border rounded-xl">
               <TaskSurveyForm taskId={task.id} onSurveySubmitted={onSaved} onCompleted={handleSurveyCompleted} />
             </div>
           </ModalDescription>
         ) : (
           <form onSubmit={handleSubmit}>
-            <ModalDescription className="flex flex-col gap-y-4 py-4 overflow-y-auto max-h-[70vh]">
+            <ModalDescription className="flex flex-col gap-y-4 py-4 overflow-y-auto max-h-[60dvh] md:max-h-[70vh]">
               <div className="bg-foreground p-4 border border-border rounded-xl">
                 <p className="text-lg font-serif font-bold text-text-dark pb-2">
                   {isAddingTask ? "Task Information" : "Details"}
@@ -573,7 +573,7 @@ function TaskDetailModalContent({ task, onOpenChange, onSaved, isAdmin }: Omit<T
                         </div>
                       ) : null}
 
-                      <div className="flex gap-x-4">
+                      <div className="flex flex-col gap-4 sm:flex-row">
                         <div className="flex-1 flex flex-col items-start gap-y-1">
                           <p className="text-text-muted font-semibold">Created</p>
                           <p className="text-text-dark font-medium">{formatDate(task?.created_at)}</p>
@@ -652,7 +652,12 @@ function TaskDetailModalContent({ task, onOpenChange, onSaved, isAdmin }: Omit<T
 
       {!isAddingTask ? (
         <Modal open={deleteConfirmationOpen} onOpenChange={setDeleteConfirmationOpen}>
-          <ModalContent className="bg-card" closeOnOverlayClick={false} showCloseButton={false} widthClassName="px-8">
+          <ModalContent
+            className="bg-card"
+            closeOnOverlayClick={false}
+            showCloseButton={false}
+            widthClassName="px-6 md:px-8"
+          >
             <ModalHeader>
               <div className="flex items-center justify-between gap-x-4">
                 <h2 className="w-full text-center text-2xl text-text-dark font-serif font-extrabold">Delete Task</h2>

--- a/src/components/TasksControlPanel.tsx
+++ b/src/components/TasksControlPanel.tsx
@@ -70,7 +70,7 @@ export function TasksControlPanel(props: TasksControlPanelProps) {
         <ControlStatusPills
           className="flex-1"
           containerClassName="w-full h-full"
-          buttonClassName="flex-1 min-w-0"
+          buttonClassName="min-w-0 sm:flex-1"
           activeIndex={statusActiveIndex}
           onActiveIndexChange={setStatusActiveIndex}
           options={STATUS_OPTIONS}

--- a/src/components/admin-page-shell.tsx
+++ b/src/components/admin-page-shell.tsx
@@ -27,10 +27,15 @@ export function AdminPageShell({
   return (
     <main className={cn("flex-1 min-w-0 min-h-full bg-background", className)} onClick={onClick}>
       {beforeContent}
-      <div className={cn("flex flex-col gap-y-8 px-6 py-10", contentClassName)}>
-        <header className={cn("flex w-full items-center justify-between pb-2", headerClassName)}>
-          <h1 className={cn("text-5xl font-serif font-semibold leading-none", titleClassName)}>{title}</h1>
-          {actions ? <div className="flex items-center gap-4">{actions}</div> : null}
+      <div className={cn("flex flex-col gap-y-6 px-4 py-6 md:gap-y-8 md:px-6 md:py-10", contentClassName)}>
+        <header
+          className={cn(
+            "flex w-full flex-col gap-4 pb-2 sm:flex-row sm:items-center sm:justify-between",
+            headerClassName,
+          )}
+        >
+          <h1 className={cn("text-4xl font-serif font-semibold leading-none md:text-5xl", titleClassName)}>{title}</h1>
+          {actions ? <div className="flex flex-wrap items-center gap-3 md:gap-4">{actions}</div> : null}
         </header>
         {children}
       </div>

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,0 +1,20 @@
+import SideNavbar from "@/components/navbar/SideNavbar";
+import MobileNavbar from "@/components/navbar/MobileNavbar";
+import { CurrentMemberProvider } from "@/hooks/useCurrentProvider";
+
+// Shared chrome for the public and admin route groups: desktop keeps the
+// fixed sidebar rail; below md it collapses into a top bar + drawer. dvh (not
+// vh) so mobile browser UI never pushes content off-screen.
+export function AppShell({ children }: { children: React.ReactNode }) {
+  return (
+    <CurrentMemberProvider>
+      <div className="flex h-dvh flex-col bg-background md:flex-row">
+        <MobileNavbar className="md:hidden" />
+        <div className="hidden items-center pl-3 md:flex">
+          <SideNavbar />
+        </div>
+        <div className="flex-1 min-w-0 overflow-y-auto">{children}</div>
+      </div>
+    </CurrentMemberProvider>
+  );
+}

--- a/src/components/assigned-tree-picker-modal.tsx
+++ b/src/components/assigned-tree-picker-modal.tsx
@@ -186,7 +186,12 @@ function AssignedTreePickerModalBody({
       </ModalDescription>
 
       <Modal open={transferConfirmTree !== null} onOpenChange={() => setTransferConfirmTree(null)}>
-        <ModalContent className="bg-card" closeOnOverlayClick={false} showCloseButton={false} widthClassName="px-8">
+        <ModalContent
+          className="bg-card"
+          closeOnOverlayClick={false}
+          showCloseButton={false}
+          widthClassName="px-6 md:px-8"
+        >
           <ModalHeader>
             <div className="flex items-center justify-between gap-x-4">
               <h2 className="w-full text-center text-2xl text-text-dark font-serif font-extrabold">Transfer Tree</h2>

--- a/src/components/data-table/pagination-controls.tsx
+++ b/src/components/data-table/pagination-controls.tsx
@@ -39,7 +39,7 @@ export default function PaginationControls<T extends Record<string, unknown>>({
         </p>
         <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
           <DropdownMenuTrigger
-            className={cn(selectTriggerClassName, "min-h-8 w-16 rounded-lg px-2 py-1 lg:w-20 lg:px-3")}
+            className={cn(selectTriggerClassName, "min-h-8 max-lg:w-16 rounded-lg px-2 py-1 lg:w-20 lg:px-3")}
           >
             <span>{table.getPageSize()}</span>
             <ChevronDown
@@ -74,7 +74,7 @@ export default function PaginationControls<T extends Record<string, unknown>>({
       </div>
       <div className="flex gap-1 items-center">
         <button
-          className={appButtonClassName({ className: "hidden lg:inline-flex", iconOnly: true, variant: "secondary" })}
+          className={appButtonClassName({ className: "max-lg:hidden", iconOnly: true, variant: "secondary" })}
           disabled={previousDisabled}
           onClick={table.firstPage}
         >
@@ -99,7 +99,7 @@ export default function PaginationControls<T extends Record<string, unknown>>({
           <ChevronRight className="w-4 h-4" />
         </button>
         <button
-          className={appButtonClassName({ className: "hidden lg:inline-flex", iconOnly: true, variant: "secondary" })}
+          className={appButtonClassName({ className: "max-lg:hidden", iconOnly: true, variant: "secondary" })}
           disabled={nextDisabled}
           onClick={table.lastPage}
         >

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -331,7 +331,9 @@ const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(function Moda
         data-state={open ? "open" : "closed"}
         className={cn(
           className,
-          "relative rounded-xl border border-border p-6 text-text-dark shadow-lg outline-none",
+          // Cap to the dynamic viewport so short phone screens scroll the
+          // dialog instead of clipping its header/footer.
+          "relative max-h-[calc(100dvh-2rem)] overflow-y-auto rounded-xl border border-border p-4 text-text-dark shadow-lg outline-none md:p-6",
           widthClassName,
         )}
         onClick={handleContentClick}

--- a/src/components/navbar/MobileNavbar.tsx
+++ b/src/components/navbar/MobileNavbar.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { LogIn, LogOut, Map, Menu, X } from "lucide-react";
+import { LogoutButton } from "../LogoutButton";
+import { useCurrentMember } from "@/hooks/useCurrentProvider";
+import { appButtonClassName } from "@/components/ui/form-controls";
+import { getVisibleNavItems } from "./nav-items";
+import { cn } from "@/lib/utils";
+
+// Mobile replacement for the desktop sidebar: a sage-green top bar with the
+// logo on the left and either a hamburger (signed in) or a Login/Map pill
+// (signed out) on the right. The hamburger opens a right-side drawer with the
+// same nav items the sidebar shows, plus Logout.
+export default function MobileNavbar({ className }: { className?: string }) {
+  const pathname = usePathname();
+  const { member, loading, isAdmin } = useCurrentMember();
+
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  const navItems = getVisibleNavItems(Boolean(member), isAdmin);
+
+  // While the drawer is open: lock background scroll, close on Escape, and
+  // move focus to the close button so keyboard users aren't stranded behind
+  // the overlay.
+  useEffect(() => {
+    if (!isDrawerOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsDrawerOpen(false);
+    };
+    document.addEventListener("keydown", handleKeyDown);
+
+    closeButtonRef.current?.focus();
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isDrawerOpen]);
+
+  // Signed-out users have no nav items, so the bar shows the relevant account
+  // action directly instead of a hamburger (mirrors the desktop sidebar's
+  // bottom slot).
+  const loggedOutAction =
+    pathname === "/login" ? (
+      <Link href="/map" className={appButtonClassName({ size: "sm", variant: "secondary" })}>
+        <Map aria-hidden="true" className="h-4 w-4" strokeWidth={2} />
+        <span>Map</span>
+      </Link>
+    ) : (
+      <Link href="/login" className={appButtonClassName({ size: "sm", variant: "secondary" })}>
+        <LogIn aria-hidden="true" className="h-4 w-4" strokeWidth={2} />
+        <span>Login</span>
+      </Link>
+    );
+
+  return (
+    <div className={cn("shrink-0", className)}>
+      <header className="flex h-16 items-center justify-between bg-primary px-4">
+        <Link href="/" className="flex items-center" aria-label="ECOSLO home">
+          <Image
+            src="/icons/ecoslo-logo.png"
+            width={44}
+            height={44}
+            alt="EcoSLO Logo"
+            className="h-11 w-11 object-contain"
+          />
+        </Link>
+        {loading ? null : member ? (
+          <button
+            type="button"
+            className="grid h-11 w-11 cursor-pointer place-items-center rounded-xl text-on-primary transition-colors hover:bg-primary-hover"
+            onClick={() => setIsDrawerOpen(true)}
+            aria-label="Open navigation menu"
+            aria-expanded={isDrawerOpen}
+          >
+            <Menu aria-hidden="true" className="h-6 w-6" strokeWidth={2} />
+          </button>
+        ) : (
+          loggedOutAction
+        )}
+      </header>
+
+      {isDrawerOpen ? (
+        <div className="fixed inset-0 z-60" role="dialog" aria-modal="true" aria-label="Navigation menu">
+          <button
+            type="button"
+            className="absolute inset-0 h-full w-full cursor-default bg-text/45"
+            aria-label="Close navigation menu"
+            onClick={() => setIsDrawerOpen(false)}
+          />
+          <div className="absolute right-0 top-0 flex h-full w-72 max-w-[85vw] flex-col overflow-y-auto overscroll-contain rounded-l-3xl bg-primary p-5">
+            <div className="mb-4 flex items-center justify-between">
+              <Image
+                src="/icons/ecoslo-logo.png"
+                width={40}
+                height={40}
+                alt="EcoSLO Logo"
+                className="h-10 w-10 object-contain"
+              />
+              <button
+                ref={closeButtonRef}
+                type="button"
+                className="grid h-11 w-11 cursor-pointer place-items-center rounded-xl text-on-primary transition-colors hover:bg-primary-hover"
+                onClick={() => setIsDrawerOpen(false)}
+                aria-label="Close navigation menu"
+              >
+                <X aria-hidden="true" className="h-6 w-6" strokeWidth={2} />
+              </button>
+            </div>
+
+            <nav className="flex flex-col gap-1.5">
+              {navItems.map((item) => {
+                const isActive = pathname === item.link || pathname.startsWith(`${item.link}/`);
+
+                return (
+                  <Link
+                    key={item.label}
+                    href={item.link}
+                    onClick={() => setIsDrawerOpen(false)}
+                    aria-current={isActive ? "page" : undefined}
+                    className={cn(
+                      "flex min-h-12 items-center gap-3 rounded-2xl px-4 py-3 font-mulish text-base text-on-primary transition-colors hover:bg-primary-hover",
+                      isActive && "bg-primary-hover font-semibold",
+                    )}
+                  >
+                    <item.icon aria-hidden="true" className="h-5 w-5" strokeWidth={1.75} />
+                    <span>{item.label}</span>
+                  </Link>
+                );
+              })}
+            </nav>
+
+            <div className="mt-auto pt-6">
+              <LogoutButton className={appButtonClassName({ className: "w-full", variant: "secondary" })}>
+                <LogOut aria-hidden="true" className="h-4 w-4" strokeWidth={2} />
+                <span>Logout</span>
+              </LogoutButton>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/navbar/SideNavbar.tsx
+++ b/src/components/navbar/SideNavbar.tsx
@@ -4,37 +4,12 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  ListChecks,
-  Calendar,
-  Ellipsis,
-  LayoutDashboard,
-  LogIn,
-  LogOut,
-  Map,
-  MapPin,
-  TreeDeciduous,
-  UsersRound,
-} from "lucide-react";
-import NavbarButton, { NavbarButtonProps } from "./SideNavbarButton";
+import { Ellipsis, LogIn, LogOut, Map } from "lucide-react";
+import NavbarButton from "./SideNavbarButton";
 import { LogoutButton } from "../LogoutButton";
 import { useCurrentMember } from "@/hooks/useCurrentProvider";
 import { appButtonClassName } from "@/components/ui/form-controls";
-
-// All possible feature buttons. Filtered by role at render time.
-// `adminOnly` flags entries hidden from Tree Keepers because RLS prevents
-// them from doing meaningful work on those pages (Reminders are admin-only;
-// Members would just show their own row).
-type FeatureButton = NavbarButtonProps & { adminOnly?: boolean };
-
-const allFeatureButtons: FeatureButton[] = [
-  { icon: LayoutDashboard, label: "Dashboard", link: "/dashboard" },
-  { icon: TreeDeciduous, label: "Trees", link: "/trees" },
-  { icon: UsersRound, label: "Members", link: "/members", adminOnly: true },
-  { icon: Calendar, label: "Reminders", link: "/reminders", adminOnly: true },
-  { icon: ListChecks, label: "Tasks", link: "/tasks" },
-  { icon: MapPin, label: "Map", link: "/map" },
-];
+import { getVisibleNavItems, type FeatureNavItem } from "./nav-items";
 
 const NAV_ITEM_HEIGHT = 88;
 const NAV_ITEM_GAP = 16;
@@ -50,10 +25,10 @@ export default function SideNavbar() {
 
   // Compute which buttons to show based on auth + role. Memoized so the
   // resize observer effect below doesn't re-run on every render.
-  const featureButtons = useMemo<FeatureButton[]>(() => {
-    if (!member) return [];
-    return allFeatureButtons.filter((button) => !button.adminOnly || isAdmin);
-  }, [member, isAdmin]);
+  const featureButtons = useMemo<FeatureNavItem[]>(
+    () => getVisibleNavItems(Boolean(member), isAdmin),
+    [member, isAdmin],
+  );
 
   // Resize observer: figure out how many buttons fit in the available space.
   // When the list overflows, the last visible slot becomes a "More" button.
@@ -159,7 +134,7 @@ export default function SideNavbar() {
   })();
 
   return (
-    <div className="sticky top-[0px] z-60 flex h-[calc(100vh-24px)] w-38 flex-col rounded-4xl bg-primary p-5">
+    <div className="sticky top-[0px] z-60 flex h-[calc(100dvh-24px)] w-38 flex-col rounded-4xl bg-primary p-5">
       <Link href="/" className="flex flex-col items-center justify-center">
         <div className="w-24.5 h-24.5 flex items-center justify-center">
           <Image

--- a/src/components/navbar/nav-items.ts
+++ b/src/components/navbar/nav-items.ts
@@ -1,0 +1,34 @@
+import {
+  Calendar,
+  LayoutDashboard,
+  ListChecks,
+  MapPin,
+  TreeDeciduous,
+  UsersRound,
+  type LucideIcon,
+} from "lucide-react";
+
+// All possible feature nav entries, shared by the desktop sidebar and the
+// mobile drawer so the two never drift apart. `adminOnly` flags entries hidden
+// from Tree Keepers because RLS prevents them from doing meaningful work on
+// those pages (Reminders are admin-only; Members would just show their own row).
+export type FeatureNavItem = {
+  icon: LucideIcon;
+  label: string;
+  link: string;
+  adminOnly?: boolean;
+};
+
+export const featureNavItems: FeatureNavItem[] = [
+  { icon: LayoutDashboard, label: "Dashboard", link: "/dashboard" },
+  { icon: TreeDeciduous, label: "Trees", link: "/trees" },
+  { icon: UsersRound, label: "Members", link: "/members", adminOnly: true },
+  { icon: Calendar, label: "Reminders", link: "/reminders", adminOnly: true },
+  { icon: ListChecks, label: "Tasks", link: "/tasks" },
+  { icon: MapPin, label: "Map", link: "/map" },
+];
+
+export function getVisibleNavItems(isLoggedIn: boolean, isAdmin: boolean): FeatureNavItem[] {
+  if (!isLoggedIn) return [];
+  return featureNavItems.filter((item) => !item.adminOnly || isAdmin);
+}

--- a/src/components/reminders/ReminderView.tsx
+++ b/src/components/reminders/ReminderView.tsx
@@ -6,7 +6,7 @@ import ReminderTextInput from "./ReminderTextInput";
 import ReminderTimePicker from "./ReminderTimePicker";
 import ReminderMonthlyDayPicker from "./ReminderMonthlyDayPicker";
 import ReminderYearlyDatePicker, { type YearlyDate } from "./ReminderYearlyDatePicker";
-import { Calendar, SquarePen, Trash2 } from "lucide-react";
+import { Calendar, ChevronLeft, SquarePen, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import ReminderLongTextInput from "./ReminderLongTextInput";
 import ReminderToggleArea from "./ReminderToggleArea";
@@ -69,6 +69,8 @@ interface ReminderViewProps {
   assigneeLabel?: string;
   members: Member[];
   mode: ReminderViewMode;
+  /** Mobile-only: returns to the reminders list pane. */
+  onBack?: () => void;
   onCancel?: () => void;
   onDeleted?: (reminderId: number) => void;
   onEdit?: () => void;
@@ -102,6 +104,7 @@ export default function ReminderView({
   assigneeLabel,
   members,
   mode,
+  onBack,
   onCancel,
   onDeleted,
   onEdit,
@@ -225,13 +228,23 @@ export default function ReminderView({
   const nextSendLabel = useMemo(() => getNextSendLabel(form), [form]);
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-6 overflow-auto no-scrollbar rounded-xl border-1 border-border bg-table-row-dark p-6">
-      <div className="flex flex-row items-center justify-between">
-        <div className="flex flex-col gap-2">
-          <h1 className="font-serif text-[26px] font-normal leading-tight">{headerTitle}</h1>
+    <div className="flex h-full min-h-0 flex-col gap-6 overflow-auto no-scrollbar rounded-xl border-1 border-border bg-table-row-dark p-4 md:p-6">
+      {onBack ? (
+        <button
+          type="button"
+          className="flex min-h-11 w-fit cursor-pointer items-center gap-1 rounded-lg pr-3 font-mulish text-sm font-semibold text-text-muted transition-colors hover:text-text md:hidden"
+          onClick={onBack}
+        >
+          <ChevronLeft aria-hidden="true" className="h-4 w-4" strokeWidth={2} />
+          <span>Back to overview</span>
+        </button>
+      ) : null}
+      <div className="flex flex-row items-center justify-between gap-3">
+        <div className="flex min-w-0 flex-col gap-2">
+          <h1 className="break-words font-serif text-[26px] font-normal leading-tight">{headerTitle}</h1>
           <span className="font-mulish text-m font-normal text-text-muted">{headerSubtitle}</span>
         </div>
-        <div className="flex flex-row items-center gap-4">
+        <div className="flex shrink-0 flex-row items-center gap-4">
           {(isViewMode || isEditMode) && (
             <AppButton
               icon={<Trash2 size={20} className="text-danger" />}
@@ -272,8 +285,8 @@ export default function ReminderView({
           />
         </div>
       )}
-      <div className="flex flex-row gap-4">
-        <div className="flex min-w-0 basis-1/2 text-text-dark">
+      <div className="flex flex-col gap-4 lg:flex-row">
+        <div className="flex w-full min-w-0 text-text-dark lg:basis-1/2">
           {isCreateMode ? (
             <ReminderDropdown
               disabled={isReadOnly}
@@ -297,7 +310,7 @@ export default function ReminderView({
             />
           )}
         </div>
-        <div className="flex min-w-0 basis-1/2 text-text-dark">
+        <div className="flex w-full min-w-0 text-text-dark lg:basis-1/2">
           <ReminderNestedMultiSelectDropdown
             disabled={isReadOnly}
             triggerClassName={viewInputBackgroundClass}
@@ -310,8 +323,8 @@ export default function ReminderView({
         </div>
       </div>
       <div className="flex flex-col gap-4">
-        <div className="flex flex-row gap-4">
-          <div className="flex basis-1/2 text-text-dark">
+        <div className="flex flex-col gap-4 lg:flex-row">
+          <div className="flex w-full text-text-dark lg:basis-1/2">
             <ReminderDropdown
               triggerClassName={viewInputBackgroundClass}
               disabled={isReadOnly}
@@ -322,7 +335,7 @@ export default function ReminderView({
               onOptionClick={handleRepeatChange}
             />
           </div>
-          <div className="flex basis-1/2 text-text-dark">
+          <div className="flex w-full text-text-dark lg:basis-1/2">
             <ReminderTimePicker
               inputClassName={viewInputBackgroundClass}
               disabled={isReadOnly}
@@ -335,8 +348,8 @@ export default function ReminderView({
         </div>
 
         {form.repeat === "weekly" && (
-          <div className="flex flex-row items-start gap-4">
-            <div className="flex basis-1/2 text-text-dark">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+            <div className="flex w-full text-text-dark lg:basis-1/2">
               <ReminderDropdown
                 disabled={isReadOnly}
                 label="Day of Week"
@@ -346,7 +359,7 @@ export default function ReminderView({
                 onOptionClick={(value) => updateForm("dayOfWeek", value)}
               />
             </div>
-            <div className="flex basis-1/2 items-center gap-4 self-end rounded-lg border border-border bg-table-header px-4 py-3">
+            <div className="flex w-full items-center gap-4 rounded-lg border border-border bg-table-header px-4 py-3 lg:basis-1/2 lg:self-end">
               <div className="flex items-center rounded-lg bg-primary p-2">
                 <Calendar className="text-on-primary" size={24} />
               </div>
@@ -409,8 +422,8 @@ export default function ReminderView({
           onChange={(event) => updateForm("message", event.target.value)}
         />
       </div>
-      <div className="flex flex-row gap-4">
-        <div className="basis-1/2">
+      <div className="flex flex-col gap-4 lg:flex-row">
+        <div className="w-full lg:basis-1/2">
           <ReminderToggleArea
             disabled={isReadOnly}
             label="Active Status"
@@ -420,7 +433,7 @@ export default function ReminderView({
             onChange={(value) => updateForm("isActive", value)}
           />
         </div>
-        <div className="basis-1/2">
+        <div className="w-full lg:basis-1/2">
           <ReminderDropdown
             triggerClassName={viewInputBackgroundClass}
             disabled={isReadOnly}
@@ -445,7 +458,7 @@ export default function ReminderView({
           />
         </div>
       ) : null}
-      <div className="basis-1/3">
+      <div className="w-full">
         <ReminderToggleArea
           disabled={isReadOnly}
           label="Set Group Task"
@@ -458,11 +471,11 @@ export default function ReminderView({
       {!isViewMode && (
         <>
           <hr className="border-0 border-t border-text-muted w-full"></hr>
-          <div className="flex flex-row gap-4">
-            <AppButton className="basis-1/2" disabled={isSubmitting} onClick={handleSubmit}>
+          <div className="flex flex-col gap-3 lg:flex-row lg:gap-4">
+            <AppButton className="w-full lg:basis-1/2" disabled={isSubmitting} onClick={handleSubmit}>
               {isSubmitting ? "Saving..." : submitLabel}
             </AppButton>
-            <AppButton className="basis-1/2" variant="secondary" onClick={onCancel}>
+            <AppButton className="w-full lg:basis-1/2" variant="secondary" onClick={onCancel}>
               Cancel
             </AppButton>
           </div>
@@ -471,7 +484,12 @@ export default function ReminderView({
       )}
 
       <Modal open={deleteConfirmationOpen} onOpenChange={setDeleteConfirmationOpen}>
-        <ModalContent className="bg-card" closeOnOverlayClick={false} showCloseButton={false} widthClassName="px-8">
+        <ModalContent
+          className="bg-card"
+          closeOnOverlayClick={false}
+          showCloseButton={false}
+          widthClassName="px-6 md:px-8"
+        >
           <ModalHeader>
             <div className="flex items-center justify-between gap-x-4">
               <h2 className="w-full text-center text-2xl text-text-dark font-serif font-extrabold">

--- a/src/components/reminders/RemindersList.tsx
+++ b/src/components/reminders/RemindersList.tsx
@@ -18,7 +18,7 @@ export default function RemindersList({
   selectedReminderId,
 }: RemindersListProps) {
   return (
-    <div className="flex max-h-full min-h-0 flex-col gap-6 overflow-hidden rounded-xl border-1 border-border bg-table-row-dark p-6">
+    <div className="flex max-h-full min-h-0 flex-col gap-4 overflow-hidden rounded-xl border-1 border-border bg-table-row-dark p-4 md:gap-6 md:p-6">
       <h2 className="font-serif text-[26px] font-normal leading-tight">Overview</h2>
       <div className="min-h-0 no-scrollbar flex flex-1 flex-col gap-4 overflow-y-auto rounded-xl">
         {reminders.length > 0 ? (

--- a/src/components/tree-detail-modal.tsx
+++ b/src/components/tree-detail-modal.tsx
@@ -509,12 +509,12 @@ function TreeDetailModalContent({ tree, onOpenChange, onSaved, isAdmin }: Omit<T
             <div className="bg-border h-px w-full" />
           </ModalHeader>
 
-          <ModalDescription className="flex flex-col gap-y-4 py-4 overflow-y-auto max-h-[70vh]">
+          <ModalDescription className="flex flex-col gap-y-4 py-4 overflow-y-auto max-h-[60dvh] md:max-h-[70vh]">
             {/* Tree Information */}
             <div className="bg-foreground p-4 border border-border rounded-xl">
               <p className="text-lg font-serif font-bold text-text-dark pb-2">Tree Information</p>
               <div className="flex flex-col gap-y-4">
-                <div className="flex gap-x-4">
+                <div className="flex flex-col gap-4 sm:flex-row">
                   <div className="flex-1 flex flex-col items-start gap-y-1">
                     <p className="text-text-muted font-semibold">
                       <span>ECOSLO #</span>
@@ -550,7 +550,7 @@ function TreeDetailModalContent({ tree, onOpenChange, onSaved, isAdmin }: Omit<T
                     )}
                   </div>
                 </div>
-                <div className="flex gap-x-4">
+                <div className="flex flex-col gap-4 sm:flex-row">
                   <div className="flex-1 flex flex-col items-start gap-y-1">
                     <p className="text-text-muted font-semibold">
                       <span>Species</span>
@@ -586,7 +586,7 @@ function TreeDetailModalContent({ tree, onOpenChange, onSaved, isAdmin }: Omit<T
                     )}
                   </div>
                 </div>
-                <div className="flex gap-x-4">
+                <div className="flex flex-col gap-4 sm:flex-row">
                   <div className="flex-1 flex flex-col items-start gap-y-1">
                     <p className="text-text-muted font-semibold">
                       <span>Funder</span>
@@ -622,7 +622,7 @@ function TreeDetailModalContent({ tree, onOpenChange, onSaved, isAdmin }: Omit<T
                     )}
                   </div>
                 </div>
-                <div className="flex gap-x-4">
+                <div className="flex flex-col gap-4 sm:flex-row">
                   <div className="flex-1 flex flex-col items-start gap-y-1">
                     <p className="text-text-muted font-semibold">Condition</p>
                     {isEditing ? (
@@ -678,7 +678,7 @@ function TreeDetailModalContent({ tree, onOpenChange, onSaved, isAdmin }: Omit<T
                     <p className="text-text-dark font-medium">{display(treeForm.address)}</p>
                   )}
                 </div>
-                <div className="flex gap-x-4">
+                <div className="flex flex-col gap-4 sm:flex-row">
                   <div className="flex-1 flex flex-col items-start gap-y-1">
                     <p className="text-text-muted font-semibold">
                       <span>Latitude</span>
@@ -751,7 +751,7 @@ function TreeDetailModalContent({ tree, onOpenChange, onSaved, isAdmin }: Omit<T
                       <p className="text-text-muted font-semibold">Name</p>
                       <p className="text-text-dark font-medium">{treeKeeper!.name}</p>
                     </div>
-                    <div className="flex gap-x-4">
+                    <div className="flex flex-col gap-4 sm:flex-row">
                       <div className="flex-1 flex flex-col items-start gap-y-1">
                         <p className="text-text-muted font-semibold">Phone</p>
                         <p className="text-text-dark font-medium">
@@ -784,7 +784,7 @@ function TreeDetailModalContent({ tree, onOpenChange, onSaved, isAdmin }: Omit<T
             <div className="bg-foreground p-4 border border-border rounded-xl">
               <p className="text-lg font-serif font-bold text-text-dark pb-2">Maintenance</p>
               <div className="flex flex-col gap-y-4">
-                <div className="flex gap-x-4">
+                <div className="flex flex-col gap-4 sm:flex-row">
                   <div className="flex-1 flex flex-col items-start gap-y-1">
                     <p className="text-text-muted font-semibold">Next Watering Date</p>
                     {isEditing && canEditAll ? (
@@ -812,7 +812,7 @@ function TreeDetailModalContent({ tree, onOpenChange, onSaved, isAdmin }: Omit<T
                     )}
                   </div>
                 </div>
-                <div className="flex gap-x-4">
+                <div className="flex flex-col gap-4 sm:flex-row">
                   <div className="flex-1 flex flex-col items-start gap-y-1">
                     <p className="text-text-muted font-semibold">Next Mulching Date</p>
                     {isEditing && canEditAll ? (
@@ -952,7 +952,12 @@ function TreeDetailModalContent({ tree, onOpenChange, onSaved, isAdmin }: Omit<T
       </ModalContent>
 
       <Modal open={duplicateEcosloNum !== null} onOpenChange={() => setDuplicateEcosloNum(null)}>
-        <ModalContent className="bg-card" closeOnOverlayClick={false} showCloseButton={false} widthClassName="px-8">
+        <ModalContent
+          className="bg-card"
+          closeOnOverlayClick={false}
+          showCloseButton={false}
+          widthClassName="px-6 md:px-8"
+        >
           <ModalHeader>
             <div className="flex items-center justify-between gap-x-4">
               <h2 className="w-full text-center text-2xl text-text-dark font-serif font-extrabold">
@@ -976,7 +981,12 @@ function TreeDetailModalContent({ tree, onOpenChange, onSaved, isAdmin }: Omit<T
       </Modal>
 
       <Modal open={deleteConfirmationOpen} onOpenChange={setDeleteConfirmationOpen}>
-        <ModalContent className="bg-card" closeOnOverlayClick={false} showCloseButton={false} widthClassName="px-8">
+        <ModalContent
+          className="bg-card"
+          closeOnOverlayClick={false}
+          showCloseButton={false}
+          widthClassName="px-6 md:px-8"
+        >
           <ModalHeader>
             <div className="flex items-center justify-between gap-x-4">
               <h2 className="w-full text-center text-2xl text-text-dark font-serif font-extrabold">

--- a/src/components/ui/form-controls.tsx
+++ b/src/components/ui/form-controls.tsx
@@ -37,9 +37,11 @@ const buttonRadiusClasses: Record<ButtonRadius, string> = {
   small: "rounded-lg",
 };
 
+// Base sizes meet the 44px mobile touch-target guidance; md: restores the
+// tighter desktop heights.
 const buttonSizeClasses: Record<ButtonSize, string> = {
-  sm: "min-h-8 px-3 py-2 text-sm",
-  md: "min-h-10 px-4 py-2.5 text-base",
+  sm: "min-h-11 px-3 py-2 text-sm md:min-h-8",
+  md: "min-h-11 px-4 py-2.5 text-base md:min-h-10",
   lg: "min-h-12 px-6 py-3 text-base",
 };
 
@@ -62,7 +64,7 @@ export function appButtonClassName({
     "disabled:cursor-not-allowed disabled:opacity-50",
     buttonVariantClasses[variant],
     buttonRadiusClasses[iconOnly ? "small" : radius],
-    iconOnly ? "h-9 w-9 p-0" : buttonSizeClasses[size],
+    iconOnly ? "h-11 w-11 p-0 md:h-9 md:w-9" : buttonSizeClasses[size],
     className,
   );
 }
@@ -270,7 +272,7 @@ export function PillGroup({ activeValue, className, optionClassName, options, on
             key={`${option.value}-${index}`}
             type="button"
             className={cn(
-              "inline-flex min-h-8 cursor-pointer select-none items-center justify-center rounded-full border px-3.5 py-1.5 font-mulish text-sm font-semibold leading-none transition-colors duration-150",
+              "inline-flex min-h-11 cursor-pointer select-none items-center justify-center rounded-full border px-3.5 py-1.5 font-mulish text-sm font-semibold leading-none transition-colors duration-150 md:min-h-8",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/25",
               isActive
                 ? "border-primary bg-primary text-on-primary hover:bg-primary-hover"

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, type ReactNode } from "react";
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 
@@ -10,24 +10,44 @@ interface TooltipProps {
   className?: string;
 }
 
-type Placement = { left: number; top: number; above: boolean };
+type Anchor = { centerX: number; top: number; bottom: number; above: boolean };
+
+const VIEWPORT_PADDING = 8;
 
 export function Tooltip({ label, children, className }: TooltipProps) {
   const triggerRef = useRef<HTMLSpanElement>(null);
-  const [placement, setPlacement] = useState<Placement | null>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [anchor, setAnchor] = useState<Anchor | null>(null);
 
   const show = () => {
     const rect = triggerRef.current?.getBoundingClientRect();
     if (!rect) return;
-    // Prefer above; flip below when too close to the top of the viewport.
-    const above = rect.top > 56;
-    setPlacement({
-      left: rect.left + rect.width / 2,
-      top: above ? rect.top - 8 : rect.bottom + 8,
-      above,
+    setAnchor({
+      centerX: rect.left + rect.width / 2,
+      top: rect.top,
+      bottom: rect.bottom,
+      // Prefer above; flip below when too close to the top of the viewport.
+      above: rect.top > 56,
     });
   };
-  const hide = () => setPlacement(null);
+  const hide = () => setAnchor(null);
+
+  // Position after render so the tooltip's measured width can be clamped to the
+  // viewport. Without this, a chip near a screen edge centers its bubble half
+  // off-screen and the text squashes into an unreadable sliver on mobile.
+  useLayoutEffect(() => {
+    const node = tooltipRef.current;
+    if (!anchor || !node) return;
+
+    const width = node.offsetWidth;
+    const maxLeft = Math.max(VIEWPORT_PADDING, window.innerWidth - width - VIEWPORT_PADDING);
+    const left = Math.min(Math.max(anchor.centerX - width / 2, VIEWPORT_PADDING), maxLeft);
+
+    node.style.left = `${left}px`;
+    node.style.top = `${anchor.above ? anchor.top - 8 : anchor.bottom + 8}px`;
+    node.style.transform = anchor.above ? "translateY(-100%)" : "none";
+    node.style.visibility = "visible";
+  }, [anchor]);
 
   return (
     <>
@@ -40,17 +60,15 @@ export function Tooltip({ label, children, className }: TooltipProps) {
       >
         {children}
       </span>
-      {placement
+      {anchor
         ? createPortal(
             <div
+              ref={tooltipRef}
               role="tooltip"
-              style={{
-                position: "fixed",
-                left: placement.left,
-                top: placement.top,
-                transform: `translateX(-50%) translateY(${placement.above ? "-100%" : "0"})`,
-              }}
-              className="pointer-events-none z-[60] max-w-xs whitespace-normal break-words rounded-md bg-text-dark px-2.5 py-1.5 text-xs font-medium text-white shadow-md"
+              // Rendered hidden at the origin first; the layout effect measures
+              // it, clamps it into the viewport, then reveals it.
+              style={{ position: "fixed", left: 0, top: 0, visibility: "hidden" }}
+              className="pointer-events-none z-[60] max-w-[calc(100vw-16px)] whitespace-normal break-words rounded-md bg-text-dark px-2.5 py-1.5 text-xs font-medium text-white shadow-md sm:max-w-xs"
             >
               {label}
             </div>,

--- a/src/components/volunteer-page-form.tsx
+++ b/src/components/volunteer-page-form.tsx
@@ -411,11 +411,11 @@ function VolunteerPageFormContent({ member, onOpenChange, onSaved }: Omit<Volunt
             </div>
             <div className="bg-border h-px w-full" />
           </ModalHeader>
-          <ModalDescription className="flex flex-col gap-y-4 py-4 overflow-y-auto max-h-[70vh]">
+          <ModalDescription className="flex flex-col gap-y-4 py-4 overflow-y-auto max-h-[60dvh] md:max-h-[70vh]">
             <div className="bg-foreground p-4 border border-border rounded-xl">
               <p className="text-lg font-serif font-bold text-text-dark pb-2">Contact Information</p>
               <div className="flex flex-col gap-y-4">
-                <div className="flex gap-x-4">
+                <div className="flex flex-col gap-4 sm:flex-row">
                   <div className="flex-1 flex flex-col items-start gap-y-1">
                     <p className="text-text-muted font-semibold">
                       <span>First Name</span>
@@ -451,7 +451,7 @@ function VolunteerPageFormContent({ member, onOpenChange, onSaved }: Omit<Volunt
                     )}
                   </div>
                 </div>
-                <div className="flex gap-x-4">
+                <div className="flex flex-col gap-4 sm:flex-row">
                   <div className="flex-1 flex flex-col items-start gap-y-1">
                     <p className="text-text-muted font-semibold">Phone</p>
                     {isEditing ? (
@@ -619,7 +619,12 @@ function VolunteerPageFormContent({ member, onOpenChange, onSaved }: Omit<Volunt
       </ModalContent>
 
       <Modal open={deleteConfirmationOpen} onOpenChange={setDeleteConfirmationOpen}>
-        <ModalContent className="bg-card" closeOnOverlayClick={false} showCloseButton={false} widthClassName="px-8">
+        <ModalContent
+          className="bg-card"
+          closeOnOverlayClick={false}
+          showCloseButton={false}
+          widthClassName="px-6 md:px-8"
+        >
           <ModalHeader>
             <div className="flex items-center justify-between gap-x-4">
               <h2 className="w-full text-center text-2xl text-text-dark font-serif font-extrabold">{`Delete ${displayedName}`}</h2>


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes N/A

### Pull Request Summary

Makes the entire app mobile-friendly. Desktop layouts are intentionally unchanged. Every modification is either mobile-only (via responsive variants) or a shared-primitive fix.

Main Changes:

- **Responsive app shell** — below `md` the fixed sidebar is replaced by a sage-green top bar (logo + hamburger when signed in, Login/Map pill when signed out) that opens a slide-in nav drawer. Desktop keeps the existing sidebar rail. All shell heights moved from `vh` to `dvh` so mobile browser chrome never cuts off content.
- **Reminders page** — single-pane flow on phones: the list shows full-width; selecting a reminder (or New Reminder) swaps to a full-width editor with a "Back to overview" button. Desktop two-pane layout is untouched (both panes stay mounted, so no state/behavior changes). Editor field pairs stack below `lg`.
- **Modals** — dialog height is capped to the dynamic viewport with scrolling, and all two-column field rows in the Tree/Member/Task detail modals stack below `sm`.
- **Map** — canvas fills its container correctly under the new top bar, the floating filter panel fits small screens, and the tree popout/report dialog were polished for phones.
- **Touch targets** — buttons, icon buttons, and filter pills are 44px on mobile while keeping current desktop sizes; page headers stack title/actions and use a ~40px title on phones.
- **Bug fixes surfaced by mobile testing** — `cn()` is a plain join (no tailwind-merge), so two same-property class conflicts never worked: the table pagination first/last buttons were never hidden below `lg`, and the page-size select ignored its `w-16` width. Both overflowed phone layouts and are fixed with deterministic variant classes (`max-lg:*`).

Trees/Members tables intentionally keep horizontal scroll inside their containers rather than converting to card lists.

### Modifications

**New**
- `src/components/app-shell.tsx` — shared shell for both route groups (mobile top bar / desktop sidebar)
- `src/components/navbar/MobileNavbar.tsx` — mobile top bar + drawer (auth-aware, body-scroll lock, Escape/overlay close)
- `src/components/navbar/nav-items.ts` — nav item definitions extracted so sidebar and drawer can't drift

**Modified**
- `src/app/(admin)/layout.tsx`, `src/app/(public)/layout.tsx` — both now render `AppShell`
- `src/components/navbar/SideNavbar.tsx` — consumes shared nav items; `dvh` height
- `src/components/admin-page-shell.tsx` — responsive header (title/actions stack), mobile gutters and title size
- `src/components/ui/form-controls.tsx` — 44px mobile touch targets for buttons/icon buttons/pills
- `src/components/modal.tsx` — viewport-capped, scrollable dialog; responsive padding
- `src/app/(admin)/reminders/page.tsx`, `src/components/reminders/ReminderView.tsx`, `RemindersList.tsx` — mobile pane swap + `onBack`, stacked field rows
- `src/components/tree-detail-modal.tsx`, `volunteer-page-form.tsx`, `TaskDetailModal.tsx`, `assigned-tree-picker-modal.tsx` — stacked field pairs, responsive scroll areas and confirm-dialog padding
- `src/components/MapClient.tsx`, `MapPopout.tsx` — container-based sizing, mobile filter panel width, bottom-sheet/report-dialog polish
- `src/components/TasksControlPanel.tsx`, `ControlPanel.tsx`, `MembersControlPanel.tsx` — status pills size naturally on phones (no truncation), equal-width from `sm` up
- `src/app/(admin)/tasks/page.tsx`, `src/components/data-table/pagination-controls.tsx` — pagination overflow fixes (`max-lg:hidden`, `max-lg:w-16`)
- `src/app/(public)/login/page.tsx` — fills shell height; responsive card padding

**Rebase**
- Rebased onto the latest develop (PRs #156 and #157); resolved conflicts in ReminderView and TaskDetailModal by keeping the new survey-mode and linked-trees functionality while reapplying the mobile-responsive layout.
- Made the newly-merged task/survey UI mobile-compatible: the task detail footer now stacks its action buttons full-width on phones (an open optional-survey task shows three buttons that previously clipped off-screen), and the new group-task tooltip is clamped to the viewport so it stays fully readable near screen edges.

### Testing Considerations

See videos below

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast


https://github.com/user-attachments/assets/f7df10ad-f81b-4fd5-92f3-23db83b49099


https://github.com/user-attachments/assets/ab7d0d82-2881-46a6-9f6d-c8c5ece902d3


https://github.com/user-attachments/assets/d028c085-9fb1-4b44-911b-ad8b75c3c81b


https://github.com/user-attachments/assets/05772c75-5b2b-4b3c-af40-4b94a9a08b87


https://github.com/user-attachments/assets/d3243f0c-6674-4bea-83ef-be57ac83f516



https://github.com/user-attachments/assets/4037e1f3-52cd-400c-9fcc-1babab300b3c



https://github.com/user-attachments/assets/b2aad946-9e6d-447c-9e0d-7b45f9edf01c

